### PR TITLE
Update Readme with release steps

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -144,7 +144,7 @@ pipeline {
                     }
                     sh "npm install jsonfile"
 
-                    sh "npm pack @zowe/cli@6.27.0"
+                    sh "npm pack @zowe/cli@6.27.1"
                     sh "npm pack @zowe/secure-credential-store-for-zowe-cli@4.1.3"
                     sh "./scripts/repackage_bundle.sh *.tgz"
                     sh "mv zowe-cli-package.zip zowe-cli-package-${ZOWE_CLI_BUNDLE_VERSION}.zip"
@@ -259,15 +259,15 @@ pipeline {
                     sh "npm install jsonfile"
 
                     sh "npm pack @zowe/imperative@4.11.2"
-                    sh "npm pack @zowe/core-for-zowe-sdk@6.27.0"
-                    sh "npm pack @zowe/provisioning-for-zowe-sdk@6.27.0"
-                    sh "npm pack @zowe/zos-console-for-zowe-sdk@6.27.0"
-                    sh "npm pack @zowe/zos-files-for-zowe-sdk@6.27.0"
-                    sh "npm pack @zowe/zos-jobs-for-zowe-sdk@6.27.0"
-                    sh "npm pack @zowe/zos-tso-for-zowe-sdk@6.27.0"
-                    sh "npm pack @zowe/zos-uss-for-zowe-sdk@6.27.0"
-                    sh "npm pack @zowe/zos-workflows-for-zowe-sdk@6.27.0"
-                    sh "npm pack @zowe/zosmf-for-zowe-sdk@6.27.0"
+                    sh "npm pack @zowe/core-for-zowe-sdk@6.27.1"
+                    sh "npm pack @zowe/provisioning-for-zowe-sdk@6.27.1"
+                    sh "npm pack @zowe/zos-console-for-zowe-sdk@6.27.1"
+                    sh "npm pack @zowe/zos-files-for-zowe-sdk@6.27.1"
+                    sh "npm pack @zowe/zos-jobs-for-zowe-sdk@6.27.1"
+                    sh "npm pack @zowe/zos-tso-for-zowe-sdk@6.27.1"
+                    sh "npm pack @zowe/zos-uss-for-zowe-sdk@6.27.1"
+                    sh "npm pack @zowe/zos-workflows-for-zowe-sdk@6.27.1"
+                    sh "npm pack @zowe/zosmf-for-zowe-sdk@6.27.1"
 
                     sh "./scripts/repackage_bundle.sh *.tgz" // Outputs a zowe-cli-package.zip
                     sh "mv zowe-cli-package.zip zowe-nodejs-sdk-${ZOWE_CLI_BUNDLE_VERSION}.zip"

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Before every Zowe release goes GA, we need to align with the code freeze dates a
 2. Check to see if the `master` build failed due to missing licenses.
     - If so, replay the build and change the license URL to a previous version
 3. Notify `Tom Zhang` on Slack and make sure to copy a link to the PR and the build that uploaded the bundles to `libs-snapshot-local` on JFrog Artifactory
-4. After the RC is approved, we may need to update the licenses URL back to the Zowe version that's about to go GA (`?????????????`)
+4. After the RC is approved and the license zip is available, we need to update the licenses URL to the Zowe version that's about to go GA.
 5. After the Zowe Release is GA, create a git tag with the version corresponding to that of the Zowe Release.
 
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Before every Zowe release goes GA, we need to align with the code freeze dates a
       zowe-cli:
         imperative: 4.11.0 -> 4.11.2
         perf-timing: 1.0.7
-        cli: 6.26.0 -> 6.27.0
+        cli: 6.26.0 -> 6.27.1
       zowe-plugins:
         cics: 4.0.2
         db2: 4.0.7 -> 4.1.0
@@ -24,15 +24,15 @@ Before every Zowe release goes GA, we need to align with the code freeze dates a
         secure-credential-store: 4.1.1 -> 4.1.3
         zos-ftp: 1.3.0 -> 1.4.0
       zowe-sdk:
-        core: 6.26.0 -> 6.27.0
-        provisioning: 6.26.0 -> 6.27.0
-        zos-console: 6.26.0 -> 6.27.0
-        zos-files: 6.26.0 -> 6.27.0
-        zos-jobs: 6.26.0 -> 6.27.0
-        zos-tso: 6.26.0 -> 6.27.0
-        zos-uss: 6.26.0 -> 6.27.0
-        zos-workflows: 6.26.0 -> 6.27.0
-        zosmf: 6.26.0 -> 6.27.0
+        core: 6.26.0 -> 6.27.1
+        provisioning: 6.26.0 -> 6.27.1
+        zos-console: 6.26.0 -> 6.27.1
+        zos-files: 6.26.0 -> 6.27.1
+        zos-jobs: 6.26.0 -> 6.27.1
+        zos-tso: 6.26.0 -> 6.27.1
+        zos-uss: 6.26.0 -> 6.27.1
+        zos-workflows: 6.26.0 -> 6.27.1
+        zosmf: 6.26.0 -> 6.27.1
       ```
 2. Check to see if the `master` build failed due to missing licenses.
     - If so, replay the build and change the license URL to a previous version

--- a/README.md
+++ b/README.md
@@ -3,3 +3,41 @@
 This repository pulls the latest Zowe CLI and Zowe CLI Plugin Artifacts from Artifactory, and generates a standalone ZIP file containing the contents.
 
 The standalone ZIP is intended to be offline-installable for those users who are unable to connect to public NPM registries. The Zowe CLI DB2 Plugin is the lone exception, as this plugin has dependencies on ODBC drivers and DDB licenses which much be obtained by users separately. See the official Zowe Documentation for more information.
+
+### Steps prior to a Zowe Release
+
+Before every Zowe release goes GA, we need to align with the code freeze dates and produce snapshots to be promoted to RCs later in the process. Follow the steps below to accomplish that.
+
+1. Create a PR into `master` with the following changes and information:
+    - Update any packages that changed after the last Zowe Release.
+    - Add a summary of the changes in the PR description like below:
+      ```
+      zowe-cli:
+        imperative: 4.11.0 -> 4.11.2
+        perf-timing: 1.0.7
+        cli: 6.26.0 -> 6.27.0
+      zowe-plugins:
+        cics: 4.0.2
+        db2: 4.0.7 -> 4.1.0
+        ims: 2.0.1
+        mq: 2.0.1
+        secure-credential-store: 4.1.1 -> 4.1.3
+        zos-ftp: 1.3.0 -> 1.4.0
+      zowe-sdk:
+        core: 6.26.0 -> 6.27.0
+        provisioning: 6.26.0 -> 6.27.0
+        zos-console: 6.26.0 -> 6.27.0
+        zos-files: 6.26.0 -> 6.27.0
+        zos-jobs: 6.26.0 -> 6.27.0
+        zos-tso: 6.26.0 -> 6.27.0
+        zos-uss: 6.26.0 -> 6.27.0
+        zos-workflows: 6.26.0 -> 6.27.0
+        zosmf: 6.26.0 -> 6.27.0
+      ```
+2. Check to see if the `master` build failed due to missing licenses.
+    - If so, replay the build and change the license URL to a previous version
+3. Notify `Tom Zhang` on Slack and make sure to copy a link to the PR and the build that uploaded the bundles to `libs-snapshot-local` on JFrog Artifactory
+4. After the RC is approved, we may need to update the licenses URL back to the Zowe version that's about to go GA (`?????????????`)
+5. After the Zowe Release is GA, create a git tag with the version corresponding to that of the Zowe Release.
+
+


### PR DESCRIPTION
Let's get this written down so we don't forget.

```
zowe-cli:
  imperative: 4.11.0 -> 4.11.2
  perf-timing: 1.0.7
  cli: 6.26.0 -> 6.27.1
zowe-plugins:
  cics: 4.0.2
  db2: 4.0.7 -> 4.1.0
  ims: 2.0.1
  mq: 2.0.1
  secure-credential-store: 4.1.1 -> 4.1.3
  zos-ftp: 1.3.0 -> 1.4.0
zowe-sdk:
  core: 6.26.0 -> 6.27.1
  provisioning: 6.26.0 -> 6.27.1
  zos-console: 6.26.0 -> 6.27.1
  zos-files: 6.26.0 -> 6.27.1
  zos-jobs: 6.26.0 -> 6.27.1
  zos-tso: 6.26.0 -> 6.27.1
  zos-uss: 6.26.0 -> 6.27.1
  zos-workflows: 6.26.0 -> 6.27.1
  zosmf: 6.26.0 -> 6.27.1
```