### PR TITLE
[1.22] Update repackaging steps for SCS plug-in

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -145,7 +145,7 @@ pipeline {
                     sh "npm install jsonfile"
 
                     sh "npm pack @zowe/cli@6.31.0"
-                    sh "npm pack @zowe/secure-credential-store-for-zowe-cli@4.1.3"
+                    sh "npm pack @zowe/secure-credential-store-for-zowe-cli@4.1.4"
                     sh "./scripts/repackage_bundle.sh *.tgz"
                     sh "mv zowe-cli-package.zip zowe-cli-package-${ZOWE_CLI_BUNDLE_VERSION}.zip"
 

--- a/scripts/repackage_bundle.sh
+++ b/scripts/repackage_bundle.sh
@@ -41,8 +41,13 @@ do
         rm -rf "./node_modules/ibm_db/installer/clidriver"
     fi
 
-    # Remove native code from Keytar module bundled with the SCS plugin
+    # Extra work required for the SCS plugin to support offline install.
+    # We include prebuilt native code bundles for Keytar and clean up unwanted binaries.
     if [[ $tar = *"secure-credential-store"* ]]; then
+        mkdir -p "./node_modules/keytar/prebuilds"
+        curl -fOJ https://wash.zowe.org:8443/job/zowe-cli-scs-plugin/job/master/lastSuccessfulBuild/artifact/keytar-prebuilds.tgz
+        tar -xzf keytar-prebuilds.tgz --directory "./node_modules/keytar/prebuilds"
+        rm keytar-prebuilds.tgz
         rm -rf "./node_modules/keytar/build"
     fi
 


### PR DESCRIPTION
⚠️ Do not merge until SCS plug-in in the Zowe CLI package is updated to v4.1.4

These changes allow the SCS plug-in to support offline install for npm@7 users.