### PR TITLE
Fix broken links in typedoc readmes

### DIFF
--- a/scripts/generate_typedoc.sh
+++ b/scripts/generate_typedoc.sh
@@ -26,6 +26,10 @@ npm init -y
 npm install -D --legacy-peer-deps @types/node typescript@^3.8.0 typedoc@^0.19.0 \
   @strictsoftware/typedoc-plugin-monorepo typedoc-plugin-sourcefile-url
 
+# Transform relative URLs to absolute URLs in Imperative and CLI readmes
+sed -i "s [(]\(CONTRIBUTING\|LICENSE\) (https://github.com/zowe/imperative/blob/v$imperativeVersion/\1 " imperative/README.md
+sed -i "s \./ https://github.com/zowe/zowe-cli/blob/v$cliVersion/ " zowe-cli/README.md
+
 # Create directory structure for Imperative and SDK packages
 mkdir -p node_modules/@zowe/imperative
 mv imperative/{packages,README.md} node_modules/@zowe/imperative/


### PR DESCRIPTION
This fix has already been tested in the v1.21.0 branch (https://github.com/zowe/zowe-cli-standalone-package/commit/4972b73d62baa035756c5849fd76416f00fb5796). It converts relative URLs to absolute URLs in readmes so that docs-site build won't detect broken links:
```
- http://zowe-docs-test-links/stable/typedoc/index.html http://zowe-docs-test-links/stable/typedoc/docs/SDKGuidelines.md "122" "404 Not Found" "-"
- http://zowe-docs-test-links/stable/typedoc/index.html http://zowe-docs-test-links/stable/typedoc/CONTRIBUTING.md "114" "404 Not Found" "-"
- http://zowe-docs-test-links/stable/typedoc/index.html http://zowe-docs-test-links/stable/typedoc/docs/TESTING.md "126" "404 Not Found" "-"
- http://zowe-docs-test-links/stable/typedoc/index.html http://zowe-docs-test-links/stable/typedoc/docs/MaintainerVersioning.md "146" "404 Not Found" "-"
- http://zowe-docs-test-links/stable/typedoc/index.html http://zowe-docs-test-links/stable/typedoc/docs/CommandFormatStandards.md "138" "404 Not Found" "-"
- http://zowe-docs-test-links/stable/typedoc/index.html http://zowe-docs-test-links/stable/typedoc/docs/PluginTESTINGGuidelines.md "130" "404 Not Found" "-"
- http://zowe-docs-test-links/stable/typedoc/index.html http://zowe-docs-test-links/stable/typedoc/docs/PackagesAndPluginGuidelines.md "118" "404 Not Found" "-"
- http://zowe-docs-test-links/stable/typedoc/modules/_zowe_imperative.html http://zowe-docs-test-links/stable/typedoc/modules/LICENSE "172" "404 Not Found" "-"
- http://zowe-docs-test-links/stable/typedoc/modules/_zowe_imperative.html http://zowe-docs-test-links/stable/typedoc/modules/CONTRIBUTING.md "164" "404 Not Found" "-"
```