### PR TITLE
Update Versions for Zowe 1.22

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -273,7 +273,7 @@ pipeline {
                     sh "npm pack @zowe/zos-files-for-zowe-sdk@6.31.1"
                     sh "npm pack @zowe/zos-jobs-for-zowe-sdk@6.31.1"
                     sh "npm pack @zowe/zos-tso-for-zowe-sdk@6.31.1"
-                    sh "npm pack @zowe/zos-uss-for-zowe-sdk@6.30.1"
+                    sh "npm pack @zowe/zos-uss-for-zowe-sdk@6.31.1"
                     sh "npm pack @zowe/zos-workflows-for-zowe-sdk@6.31.1"
                     sh "npm pack @zowe/zosmf-for-zowe-sdk@6.31.1"
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -150,9 +150,9 @@ pipeline {
                     }
                     sh "npm install jsonfile"
 
-                    script { zoweCliVersion = "6.31.0" }
+                    script { zoweCliVersion = "6.31.1" }
                     sh "npm pack @zowe/cli@${zoweCliVersion}"
-                    sh "npm pack @zowe/secure-credential-store-for-zowe-cli@4.1.4"
+                    sh "npm pack @zowe/secure-credential-store-for-zowe-cli@4.1.5"
                     sh "./scripts/repackage_bundle.sh *.tgz"
                     sh "mv zowe-cli-package.zip zowe-cli-package-${ZOWE_CLI_BUNDLE_VERSION}.zip"
 
@@ -211,7 +211,7 @@ pipeline {
                     sh "npm pack @zowe/cics-for-zowe-cli@4.0.2"
                     sh "npm pack @zowe/ims-for-zowe-cli@2.0.1"
                     sh "npm pack @zowe/mq-for-zowe-cli@2.0.1"
-                    sh "npm pack @zowe/zos-ftp-for-zowe-cli@1.4.1"
+                    sh "npm pack @zowe/zos-ftp-for-zowe-cli@1.6.0"
                     sh "./scripts/repackage_bundle.sh *.tgz"
                     sh "mv zowe-cli-package.zip zowe-cli-plugins-${ZOWE_CLI_BUNDLE_VERSION}.zip"
 
@@ -265,17 +265,17 @@ pipeline {
                     }
                     sh "npm install jsonfile"
 
-                    script { imperativeVersion = "4.13.0" }
+                    script { imperativeVersion = "4.13.1" }
                     sh "npm pack @zowe/imperative@${imperativeVersion}"
-                    sh "npm pack @zowe/core-for-zowe-sdk@6.31.0"
-                    sh "npm pack @zowe/provisioning-for-zowe-sdk@6.31.0"
-                    sh "npm pack @zowe/zos-console-for-zowe-sdk@6.31.0"
-                    sh "npm pack @zowe/zos-files-for-zowe-sdk@6.31.0"
-                    sh "npm pack @zowe/zos-jobs-for-zowe-sdk@6.31.0"
-                    sh "npm pack @zowe/zos-tso-for-zowe-sdk@6.31.0"
-                    sh "npm pack @zowe/zos-uss-for-zowe-sdk@6.30.0"
-                    sh "npm pack @zowe/zos-workflows-for-zowe-sdk@6.31.0"
-                    sh "npm pack @zowe/zosmf-for-zowe-sdk@6.31.0"
+                    sh "npm pack @zowe/core-for-zowe-sdk@6.31.1"
+                    sh "npm pack @zowe/provisioning-for-zowe-sdk@6.31.1"
+                    sh "npm pack @zowe/zos-console-for-zowe-sdk@6.31.1"
+                    sh "npm pack @zowe/zos-files-for-zowe-sdk@6.31.1"
+                    sh "npm pack @zowe/zos-jobs-for-zowe-sdk@6.31.1"
+                    sh "npm pack @zowe/zos-tso-for-zowe-sdk@6.31.1"
+                    sh "npm pack @zowe/zos-uss-for-zowe-sdk@6.30.1"
+                    sh "npm pack @zowe/zos-workflows-for-zowe-sdk@6.31.1"
+                    sh "npm pack @zowe/zosmf-for-zowe-sdk@6.31.1"
 
                     sh "./scripts/repackage_bundle.sh *.tgz" // Outputs a zowe-cli-package.zip
                     sh "mv zowe-cli-package.zip zowe-nodejs-sdk-${ZOWE_CLI_BUNDLE_VERSION}.zip"

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Before every Zowe release goes GA, we need to align with the code freeze dates a
         cli: 6.31.0 -> 6.31.1
       zowe-plugins:
         cics: 4.0.2
-        db2: 4.0.7 -> 4.1.0
+        db2: 4.1.0
         ims: 2.0.1
         mq: 2.0.1
         secure-credential-store: 4.1.4 -> 4.1.5

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Before every Zowe release goes GA, we need to align with the code freeze dates a
         db2: 4.1.0
         ims: 2.0.1
         mq: 2.0.1
-        secure-credential-store: 4.1.4 -> 4.1.5
+        secure-credential-store: 4.1.3 -> 4.1.5
         zos-ftp: 1.4.1 -> 1.6.0
       zowe-sdk:
         core: 6.31.0 -> 6.31.1

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Before every Zowe release goes GA, we need to align with the code freeze dates a
         zos-files: 6.31.0 -> 6.31.1
         zos-jobs: 6.31.0 -> 6.31.1
         zos-tso: 6.31.0 -> 6.31.1
-        zos-uss: 6.31.0 -> 6.31.1
+        zos-uss: 6.30.0 -> 6.31.1
         zos-workflows: 6.31.0 -> 6.31.1
         zosmf: 6.31.0 -> 6.31.1
         ```

--- a/README.md
+++ b/README.md
@@ -11,29 +11,29 @@ Before every Zowe release goes GA, we need to align with the code freeze dates a
 1. Create a PR into `master` with the following changes and information:
     - Update any packages that changed after the last Zowe Release.
     - Add a summary of the changes in the PR description like below:
-      ```
+      ```yaml
       zowe-cli:
-        imperative: 4.11.0 -> 4.11.2
+        imperative: 4.13.0 -> 4.13.1
         perf-timing: 1.0.7
-        cli: 6.26.0 -> 6.27.1
+        cli: 6.31.0 -> 6.31.1
       zowe-plugins:
         cics: 4.0.2
         db2: 4.0.7 -> 4.1.0
         ims: 2.0.1
         mq: 2.0.1
-        secure-credential-store: 4.1.1 -> 4.1.3
-        zos-ftp: 1.3.0 -> 1.4.0
+        secure-credential-store: 4.1.4 -> 4.1.5
+        zos-ftp: 1.4.1 -> 1.6.0
       zowe-sdk:
-        core: 6.26.0 -> 6.27.0
-        provisioning: 6.26.0 -> 6.27.0
-        zos-console: 6.26.0 -> 6.27.0
-        zos-files: 6.26.0 -> 6.27.0
-        zos-jobs: 6.26.0 -> 6.27.0
-        zos-tso: 6.26.0 -> 6.27.1
-        zos-uss: 6.26.0 -> 6.27.0
-        zos-workflows: 6.26.0 -> 6.27.0
-        zosmf: 6.26.0 -> 6.27.1
-      ```
+        core: 6.31.0 -> 6.31.1
+        provisioning: 6.31.0 -> 6.31.1
+        zos-console: 6.31.0 -> 6.31.1
+        zos-files: 6.31.0 -> 6.31.1
+        zos-jobs: 6.31.0 -> 6.31.1
+        zos-tso: 6.31.0 -> 6.31.1
+        zos-uss: 6.31.0 -> 6.31.1
+        zos-workflows: 6.31.0 -> 6.31.1
+        zosmf: 6.31.0 -> 6.31.1
+        ```
 2. Check to see if the `master` build failed due to missing licenses.
     - If so, replay the build and change the license URL to a previous version
 3. Notify `Tom Zhang` on Slack and make sure to copy a link to the PR and the build that uploaded the bundles to `libs-snapshot-local` on JFrog Artifactory


### PR DESCRIPTION
```yaml
zowe-cli:
  imperative: 4.13.0 -> 4.13.1
  perf-timing: 1.0.7
  cli: 6.31.0 -> 6.31.1
zowe-plugins:
  cics: 4.0.2
  db2: 4.1.0
  ims: 2.0.1
  mq: 2.0.1
  secure-credential-store: 4.1.4 -> 4.1.5
  zos-ftp: 1.4.1 -> 1.6.0
zowe-sdk:
  core: 6.31.0 -> 6.31.1
  provisioning: 6.31.0 -> 6.31.1
  zos-console: 6.31.0 -> 6.31.1
  zos-files: 6.31.0 -> 6.31.1
  zos-jobs: 6.31.0 -> 6.31.1
  zos-tso: 6.31.0 -> 6.31.1
  zos-uss: 6.31.0 -> 6.31.1
  zos-workflows: 6.31.0 -> 6.31.1
  zosmf: 6.31.0 -> 6.31.1
  ```