### PR TITLE
Create packages for Zowe v2 LTS Preview

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -174,7 +174,7 @@ pipeline {
                                         sh "../scripts/repackage_bundle.sh *.tgz"
                                         sh "mv zowe-cli-package.zip ../zowe-cli-package-${ZOWE_CLI_BUNDLE_VERSION}.zip"
 
-                                        archiveArtifacts artifacts: "../zowe-cli-package-${ZOWE_CLI_BUNDLE_VERSION}.zip"
+                                        archiveArtifacts artifacts: "zowe-cli-package-${ZOWE_CLI_BUNDLE_VERSION}.zip"
 
                                         // Remove all tgzs after bundle is archived
                                         sh "rm -f *.tgz"
@@ -220,7 +220,7 @@ pipeline {
                                         sh "../scripts/repackage_bundle.sh *.tgz"
                                         sh "mv zowe-cli-package.zip ../zowe-cli-plugins-${ZOWE_CLI_BUNDLE_VERSION}.zip"
 
-                                        archiveArtifacts artifacts: "../zowe-cli-plugins-${ZOWE_CLI_BUNDLE_VERSION}.zip"
+                                        archiveArtifacts artifacts: "zowe-cli-plugins-${ZOWE_CLI_BUNDLE_VERSION}.zip"
 
                                         // Remove all tgzs after bundle is archived
                                         sh "rm -f *.tgz"
@@ -275,7 +275,7 @@ pipeline {
                                         sh "../scripts/generate_typedoc.sh ${ZOWE_CLI_BUNDLE_VERSION} ${imperativeVersion} ${zoweCliVersion}" // Outputs a zowe-node-sdk-typedoc.zip
                                         sh "mv zowe-node-sdk-typedoc.zip ../zowe-nodejs-sdk-typedoc-${ZOWE_CLI_BUNDLE_VERSION}.zip"
 
-                                        archiveArtifacts artifacts: "../zowe-nodejs-sdk*-${ZOWE_CLI_BUNDLE_VERSION}.zip"
+                                        archiveArtifacts artifacts: "zowe-nodejs-sdk*-${ZOWE_CLI_BUNDLE_VERSION}.zip"
 
                                         // Remove all tgzs after bundle is archived
                                         sh "rm -f *.tgz"
@@ -317,7 +317,7 @@ pipeline {
 
                                         // Archive the zowe Python SDK
                                         sh "mv zowe-sdk.zip ../zowe-python-sdk-${ZOWE_CLI_BUNDLE_VERSION}.zip"
-                                        archiveArtifacts artifacts: "../zowe-python-sdk-${ZOWE_CLI_BUNDLE_VERSION}.zip"
+                                        archiveArtifacts artifacts: "zowe-python-sdk-${ZOWE_CLI_BUNDLE_VERSION}.zip"
                                     }
                                 }
                             }
@@ -363,7 +363,7 @@ pipeline {
                                         sh "../scripts/repackage_bundle.sh *.tgz"
                                         sh "mv zowe-cli-package.zip ../zowe-cli-package-${ZOWE_CLI_BUNDLE_NEXT_VERSION}.zip"
 
-                                        archiveArtifacts artifacts: "../zowe-cli-package-${ZOWE_CLI_BUNDLE_NEXT_VERSION}.zip"
+                                        archiveArtifacts artifacts: "zowe-cli-package-${ZOWE_CLI_BUNDLE_NEXT_VERSION}.zip"
 
                                         // Remove all tgzs after bundle is archived
                                         sh "rm -f *.tgz"
@@ -411,7 +411,7 @@ pipeline {
                                         sh "../scripts/repackage_bundle.sh *.tgz"
                                         sh "mv zowe-cli-package.zip ../zowe-cli-plugins-${ZOWE_CLI_BUNDLE_NEXT_VERSION}.zip"
 
-                                        archiveArtifacts artifacts: "../zowe-cli-plugins-${ZOWE_CLI_BUNDLE_NEXT_VERSION}.zip"
+                                        archiveArtifacts artifacts: "zowe-cli-plugins-${ZOWE_CLI_BUNDLE_NEXT_VERSION}.zip"
 
                                         // Remove all tgzs after bundle is archived
                                         sh "rm -f *.tgz"
@@ -466,7 +466,7 @@ pipeline {
                                         sh "../scripts/generate_typedoc.sh next" // Outputs a zowe-node-sdk-typedoc.zip
                                         sh "mv zowe-node-sdk-typedoc.zip ../zowe-nodejs-sdk-typedoc-${ZOWE_CLI_BUNDLE_NEXT_VERSION}.zip"
 
-                                        archiveArtifacts artifacts: "../zowe-nodejs-sdk*-${ZOWE_CLI_BUNDLE_NEXT_VERSION}.zip"
+                                        archiveArtifacts artifacts: "zowe-nodejs-sdk*-${ZOWE_CLI_BUNDLE_NEXT_VERSION}.zip"
 
                                         // Remove all tgzs after bundle is archived
                                         sh "rm -f *.tgz"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -121,7 +121,7 @@ pipeline {
                     withCredentials([usernamePassword(credentialsId: ARTIFACTORY_CREDENTIALS_ID, usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD')]) {
                         // TODO: Consider using tooling like artifactory-download-spec to get license.zip. Post-Infrastructure migration answer.
                         sh "mkdir -p licenses && cd licenses && curl -fs -o zowe_licenses_full.zip $ZOWE_LICENSE_ZIP_URL"
-                        sh "../scripts/npm_login.sh $USERNAME $PASSWORD \"$ARTIFACTORY_EMAIL\" '--registry=${ZOWE_ARTIFACTORY_URL} --scope=@zowe'"
+                        sh "./scripts/npm_login.sh $USERNAME $PASSWORD \"$ARTIFACTORY_EMAIL\" '--registry=${ZOWE_ARTIFACTORY_URL} --scope=@zowe'"
                     }
                     sh "npm install jsonfile"
                 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -120,7 +120,7 @@ pipeline {
                     sh "npm set @zowe:registry ${ZOWE_ARTIFACTORY_URL}"
                     withCredentials([usernamePassword(credentialsId: ARTIFACTORY_CREDENTIALS_ID, usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD')]) {
                         // TODO: Consider using tooling like artifactory-download-spec to get license.zip. Post-Infrastructure migration answer.
-                        sh "mkdir -p licenses && cd licenses && curl -fs -o zowe_licenses_full.zip $ZOWE_LICENSE_ZIP_URL"
+                        sh "curl -fs -o zowe_licenses_full.zip $ZOWE_LICENSE_ZIP_URL"
                         sh "./scripts/npm_login.sh $USERNAME $PASSWORD \"$ARTIFACTORY_EMAIL\" '--registry=${ZOWE_ARTIFACTORY_URL} --scope=@zowe'"
                     }
                     sh "npm install jsonfile"
@@ -166,7 +166,7 @@ pipeline {
                             steps {
                                 dir("lts") {
                                     timeout(time: 10, unit: 'MINUTES') {
-                                        sh "cp ../zowe_licenses_full.zip zowe_licenses_full.zip"
+                                        sh "mkdir -p licenses && cd licenses && cp ../../zowe_licenses_full.zip zowe_licenses_full.zip"
 
                                         script { zoweCliVersion = "6.31.1" }
                                         sh "npm pack @zowe/cli@${zoweCliVersion}"
@@ -210,7 +210,7 @@ pipeline {
                             steps {
                                 dir("lts") {
                                     timeout(time: 10, unit: 'MINUTES') {
-                                        sh "cp ../zowe_licenses_full.zip zowe_licenses_full.zip"
+                                        sh "mkdir -p licenses && cd licenses && cp ../../zowe_licenses_full.zip zowe_licenses_full.zip"
 
                                         sh "npm pack @zowe/db2-for-zowe-cli@4.1.0"
                                         sh "npm pack @zowe/cics-for-zowe-cli@4.0.2"
@@ -255,7 +255,7 @@ pipeline {
                             steps {
                                 dir("lts") {
                                     timeout(time: 10, unit: 'MINUTES') {
-                                        sh "cp ../zowe_licenses_full.zip zowe_licenses_full.zip"
+                                        sh "mkdir -p licenses && cd licenses && cp ../../zowe_licenses_full.zip zowe_licenses_full.zip"
 
                                         script { imperativeVersion = "4.13.1" }
                                         sh "npm pack @zowe/imperative@${imperativeVersion}"
@@ -354,7 +354,7 @@ pipeline {
                             steps {
                                 dir("next") {
                                     timeout(time: 10, unit: 'MINUTES') {
-                                        sh "cp ../zowe_licenses_full.zip zowe_licenses_full.zip"
+                                        sh "mkdir -p licenses && cd licenses && cp ../../zowe_licenses_full.zip zowe_licenses_full.zip"
 
                                         script { zoweCliVersion = "next" }
                                         sh "npm pack @zowe/cli@${zoweCliVersion}"
@@ -399,7 +399,7 @@ pipeline {
                             steps {
                                 dir("next") {
                                     timeout(time: 10, unit: 'MINUTES') {
-                                        sh "cp ../zowe_licenses_full.zip zowe_licenses_full.zip"
+                                        sh "mkdir -p licenses && cd licenses && cp ../../zowe_licenses_full.zip zowe_licenses_full.zip"
 
                                         sh "npm pack @zowe/db2-for-zowe-cli@next"
                                         sh "npm pack @zowe/cics-for-zowe-cli@next"
@@ -446,7 +446,7 @@ pipeline {
                             steps {
                                 dir("next") {
                                     timeout(time: 10, unit: 'MINUTES') {
-                                        sh "cp ../zowe_licenses_full.zip zowe_licenses_full.zip"
+                                        sh "mkdir -p licenses && cd licenses && cp ../../zowe_licenses_full.zip zowe_licenses_full.zip"
 
                                         script { imperativeVersion = "next" }
                                         sh "npm pack @zowe/imperative@${imperativeVersion}"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -58,7 +58,7 @@ def ZOWE_ARTIFACTORY_URL = "https://zowe.jfrog.io/zowe/api/npm/npm-local-release
 * The Zowe CLI Bundle Version to deploy to Artifactory
 */
 def ZOWE_CLI_BUNDLE_VERSION = "1.22.0-SNAPSHOT"
-def ZOWE_CLI_BUNDLE_NEXT_VERSION = "next-$ZOWE_CLI_BUNDLE_VERSION"
+def ZOWE_CLI_BUNDLE_NEXT_VERSION = "next-${new Date().format("yyyyMMdd")}-SNAPSHOT"
 def ZOWE_VERSION_NUMBER = "1.22.0"
 
 /**

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -114,6 +114,14 @@ pipeline {
 
     stages {
         stage('Create Bundles') {
+            when {
+                allOf {
+                    expression {
+                        return BRANCH_NAME.equals(MASTER_BRANCH)
+                    }
+                }
+            }
+            failFast true
             parallel {
                 stage('Create Bundles (LTS)') {
                     stages {
@@ -141,13 +149,6 @@ pipeline {
                         * A Zowe CLI Archive containing Zowe CLI and Zowe CLI Secure Credential Store Plugin
                         ************************************************************************/
                         stage('CLI Core (LTS)') {
-                            when {
-                                allOf {
-                                    expression {
-                                        return BRANCH_NAME.equals(MASTER_BRANCH)
-                                    }
-                                }
-                            }
                             steps {
                                 dir("lts") {
                                     timeout(time: 10, unit: 'MINUTES') {
@@ -199,13 +200,6 @@ pipeline {
                         * Zowe CLI z/OS FTP Plugin, Zowe CLI IMS Plugin, and Zowe CLI MQ Plugin.
                         ************************************************************************/
                         stage('CLI Plugins (LTS)') {
-                            when {
-                                allOf {
-                                    expression {
-                                        return BRANCH_NAME.equals(MASTER_BRANCH)
-                                    }
-                                }
-                            }
                             steps {
                                 dir("lts") {
                                     timeout(time: 10, unit: 'MINUTES') {
@@ -258,13 +252,6 @@ pipeline {
                         * A Zowe NodeJS SDK Archive.
                         ************************************************************************/
                         stage('NodeJS SDK (LTS)') {
-                            when {
-                                allOf {
-                                    expression {
-                                        return BRANCH_NAME.equals(MASTER_BRANCH)
-                                    }
-                                }
-                            }
                             steps {
                                 dir("lts") {
                                     timeout(time: 10, unit: 'MINUTES') {
@@ -325,13 +312,6 @@ pipeline {
                         * A Zowe Python SDK Archive.
                         ************************************************************************/
                         stage('Python SDK (LTS)') {
-                            when {
-                                allOf {
-                                    expression {
-                                        return BRANCH_NAME.equals(MASTER_BRANCH)
-                                    }
-                                }
-                            }
                             steps {
                                 dir("lts") {
                                     timeout(time: 10, unit: 'MINUTES') {
@@ -378,13 +358,6 @@ pipeline {
                         * A Zowe CLI Archive containing Zowe CLI and Zowe CLI Secure Credential Store Plugin
                         ************************************************************************/
                         stage('CLI Core (Next)') {
-                            when {
-                                allOf {
-                                    expression {
-                                        return BRANCH_NAME.equals(MASTER_BRANCH)
-                                    }
-                                }
-                            }
                             steps {
                                 dir("next") {
                                     timeout(time: 10, unit: 'MINUTES') {
@@ -437,13 +410,6 @@ pipeline {
                         * Zowe CLI z/OS FTP Plugin, Zowe CLI IMS Plugin, and Zowe CLI MQ Plugin.
                         ************************************************************************/
                         stage('CLI Plugins (Next)') {
-                            when {
-                                allOf {
-                                    expression {
-                                        return BRANCH_NAME.equals(MASTER_BRANCH)
-                                    }
-                                }
-                            }
                             steps {
                                 dir("next") {
                                     timeout(time: 10, unit: 'MINUTES') {
@@ -498,13 +464,6 @@ pipeline {
                         * A Zowe NodeJS SDK Archive.
                         ************************************************************************/
                         stage('NodeJS SDK (Next)') {
-                            when {
-                                allOf {
-                                    expression {
-                                        return BRANCH_NAME.equals(MASTER_BRANCH)
-                                    }
-                                }
-                            }
                             steps {
                                 dir("next") {
                                     timeout(time: 10, unit: 'MINUTES') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -90,12 +90,12 @@ def ZOWE_LICENSE_ZIP_URL = "https://zowe.jfrog.io/zowe/$ARTIFACTORY_RELEASE_REPO
 /**
 * Master branch
 */
-def MASTER_BRANCH = "publish-next"
+def MASTER_BRANCH = "master"
 
 /**
-* If true, no artifacts will be published even when branch is MASTER_BRANCH
+* If true, the pipeline will run on any branch without publishing artifacts
 */
-def DRY_RUN = true
+def DRY_RUN = env.CHANGE_ID != null
 
 /**
 * Variables defined later in pipeline
@@ -149,7 +149,7 @@ pipeline {
             when {
                 allOf {
                     expression {
-                        return BRANCH_NAME.equals(MASTER_BRANCH)
+                        return BRANCH_NAME.equals(MASTER_BRANCH) || DRY_RUN
                     }
                 }
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -113,6 +113,15 @@ pipeline {
     }
 
     stages {
+        /************************************************************************
+        * STAGE
+        * -----
+        * Setup
+        *
+        * DESCRIPTION
+        * ----------
+        * Logs in to NPM registry, downloads licenses ZIP, and installs dependencies
+        ************************************************************************/
         stage('Setup') {
             steps {
                 timeout(time: 5, unit: 'MINUTES') {
@@ -127,6 +136,15 @@ pipeline {
                 }
             }
         }
+        /************************************************************************
+        * STAGE
+        * -----
+        * Create Bundles
+        *
+        * DESCRIPTION
+        * ----------
+        * Builds Zowe CLI and SDK bundles for both LTS and Next releases
+        ************************************************************************/
         stage('Create Bundles') {
             when {
                 allOf {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -58,7 +58,7 @@ def ZOWE_ARTIFACTORY_URL = "https://zowe.jfrog.io/zowe/api/npm/npm-local-release
 * The Zowe CLI Bundle Version to deploy to Artifactory
 */
 def ZOWE_CLI_BUNDLE_VERSION = "1.22.0-SNAPSHOT"
-def ZOWE_CLI_BUNDLE_NEXT_VERSION = "2.0.0-preview-SNAPSHOT"
+def ZOWE_CLI_BUNDLE_NEXT_VERSION = "next-$ZOWE_CLI_BUNDLE_VERSION"
 def ZOWE_VERSION_NUMBER = "1.22.0"
 
 /**
@@ -113,6 +113,16 @@ pipeline {
     }
 
     stages {
+        stage('Setup') {
+            sh "npm set registry https://registry.npmjs.org/"
+            sh "npm set @zowe:registry ${ZOWE_ARTIFACTORY_URL}"
+            withCredentials([usernamePassword(credentialsId: ARTIFACTORY_CREDENTIALS_ID, usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD')]) {
+                // TODO: Consider using tooling like artifactory-download-spec to get license.zip. Post-Infrastructure migration answer.
+                sh "mkdir -p licenses && cd licenses && curl -fs -o zowe_licenses_full.zip $ZOWE_LICENSE_ZIP_URL"
+                sh "../scripts/npm_login.sh $USERNAME $PASSWORD \"$ARTIFACTORY_EMAIL\" '--registry=${ZOWE_ARTIFACTORY_URL} --scope=@zowe'"
+            }
+            sh "npm install jsonfile"
+        }
         stage('Create Bundles') {
             when {
                 allOf {
@@ -152,14 +162,7 @@ pipeline {
                             steps {
                                 dir("lts") {
                                     timeout(time: 10, unit: 'MINUTES') {
-                                        sh "npm set registry https://registry.npmjs.org/"
-                                        sh "npm set @zowe:registry ${ZOWE_ARTIFACTORY_URL}"
-                                        withCredentials([usernamePassword(credentialsId: ARTIFACTORY_CREDENTIALS_ID, usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD')]) {
-                                            // TODO: Consider using tooling like artifactory-download-spec to get license.zip. Post-Infrastructure migration answer.
-                                            sh "mkdir -p licenses && cd licenses && curl -fs -o zowe_licenses_full.zip $ZOWE_LICENSE_ZIP_URL"
-                                            sh "../scripts/npm_login.sh $USERNAME $PASSWORD \"$ARTIFACTORY_EMAIL\" '--registry=${ZOWE_ARTIFACTORY_URL} --scope=@zowe'"
-                                        }
-                                        sh "npm install jsonfile"
+                                        sh "cp ../zowe_licenses_full.zip zowe_licenses_full.zip"
 
                                         script { zoweCliVersion = "6.31.1" }
                                         sh "npm pack @zowe/cli@${zoweCliVersion}"
@@ -203,14 +206,7 @@ pipeline {
                             steps {
                                 dir("lts") {
                                     timeout(time: 10, unit: 'MINUTES') {
-                                        sh "npm set registry https://registry.npmjs.org/"
-                                        sh "npm set @zowe:registry ${ZOWE_ARTIFACTORY_URL}"
-                                        withCredentials([usernamePassword(credentialsId: ARTIFACTORY_CREDENTIALS_ID, usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD')]) {
-                                            // TODO: Consider using tooling like artifactory-download-spec to get license.zip. Post-Infrastructure migration answer.
-                                            sh "mkdir -p licenses && cd licenses && curl -fs -o zowe_licenses_full.zip $ZOWE_LICENSE_ZIP_URL"
-                                            sh "../scripts/npm_login.sh $USERNAME $PASSWORD \"$ARTIFACTORY_EMAIL\" '--registry=${ZOWE_ARTIFACTORY_URL} --scope=@zowe'"
-                                        }
-                                        sh "npm install jsonfile"
+                                        sh "cp ../zowe_licenses_full.zip zowe_licenses_full.zip"
 
                                         sh "npm pack @zowe/db2-for-zowe-cli@4.1.0"
                                         sh "npm pack @zowe/cics-for-zowe-cli@4.0.2"
@@ -255,14 +251,7 @@ pipeline {
                             steps {
                                 dir("lts") {
                                     timeout(time: 10, unit: 'MINUTES') {
-                                        sh "npm set registry https://registry.npmjs.org/"
-                                        sh "npm set @zowe:registry ${ZOWE_ARTIFACTORY_URL}"
-                                        withCredentials([usernamePassword(credentialsId: ARTIFACTORY_CREDENTIALS_ID, usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD')]) {
-                                            // TODO: Consider using tooling like artifactory-download-spec to get license.zip. Post-Infrastructure migration answer.
-                                            sh "mkdir -p licenses && cd licenses && curl -fs -o zowe_licenses_full.zip $ZOWE_LICENSE_ZIP_URL"
-                                            sh "../scripts/npm_login.sh $USERNAME $PASSWORD \"$ARTIFACTORY_EMAIL\" '--registry=${ZOWE_ARTIFACTORY_URL} --scope=@zowe'"
-                                        }
-                                        sh "npm install jsonfile"
+                                        sh "cp ../zowe_licenses_full.zip zowe_licenses_full.zip"
 
                                         script { imperativeVersion = "4.13.1" }
                                         sh "npm pack @zowe/imperative@${imperativeVersion}"
@@ -361,14 +350,7 @@ pipeline {
                             steps {
                                 dir("next") {
                                     timeout(time: 10, unit: 'MINUTES') {
-                                        sh "npm set registry https://registry.npmjs.org/"
-                                        sh "npm set @zowe:registry ${ZOWE_ARTIFACTORY_URL}"
-                                        withCredentials([usernamePassword(credentialsId: ARTIFACTORY_CREDENTIALS_ID, usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD')]) {
-                                            // TODO: Consider using tooling like artifactory-download-spec to get license.zip. Post-Infrastructure migration answer.
-                                            sh "mkdir -p licenses && cd licenses && curl -fs -o zowe_licenses_full.zip $ZOWE_LICENSE_ZIP_URL"
-                                            sh "../scripts/npm_login.sh $USERNAME $PASSWORD \"$ARTIFACTORY_EMAIL\" '--registry=${ZOWE_ARTIFACTORY_URL} --scope=@zowe'"
-                                        }
-                                        sh "npm install jsonfile"
+                                        sh "cp ../zowe_licenses_full.zip zowe_licenses_full.zip"
 
                                         script { zoweCliVersion = "next" }
                                         sh "npm pack @zowe/cli@${zoweCliVersion}"
@@ -413,14 +395,7 @@ pipeline {
                             steps {
                                 dir("next") {
                                     timeout(time: 10, unit: 'MINUTES') {
-                                        sh "npm set registry https://registry.npmjs.org/"
-                                        sh "npm set @zowe:registry ${ZOWE_ARTIFACTORY_URL}"
-                                        withCredentials([usernamePassword(credentialsId: ARTIFACTORY_CREDENTIALS_ID, usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD')]) {
-                                            // TODO: Consider using tooling like artifactory-download-spec to get license.zip. Post-Infrastructure migration answer.
-                                            sh "mkdir -p licenses && cd licenses && curl -fs -o zowe_licenses_full.zip $ZOWE_LICENSE_ZIP_URL"
-                                            sh "../scripts/npm_login.sh $USERNAME $PASSWORD \"$ARTIFACTORY_EMAIL\" '--registry=${ZOWE_ARTIFACTORY_URL} --scope=@zowe'"
-                                        }
-                                        sh "npm install jsonfile"
+                                        sh "cp ../zowe_licenses_full.zip zowe_licenses_full.zip"
 
                                         sh "npm pack @zowe/db2-for-zowe-cli@next"
                                         sh "npm pack @zowe/cics-for-zowe-cli@next"
@@ -467,14 +442,7 @@ pipeline {
                             steps {
                                 dir("next") {
                                     timeout(time: 10, unit: 'MINUTES') {
-                                        sh "npm set registry https://registry.npmjs.org/"
-                                        sh "npm set @zowe:registry ${ZOWE_ARTIFACTORY_URL}"
-                                        withCredentials([usernamePassword(credentialsId: ARTIFACTORY_CREDENTIALS_ID, usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD')]) {
-                                            // TODO: Consider using tooling like artifactory-download-spec to get license.zip. Post-Infrastructure migration answer.
-                                            sh "mkdir -p licenses && cd licenses && curl -fs -o zowe_licenses_full.zip $ZOWE_LICENSE_ZIP_URL"
-                                            sh "../scripts/npm_login.sh $USERNAME $PASSWORD \"$ARTIFACTORY_EMAIL\" '--registry=${ZOWE_ARTIFACTORY_URL} --scope=@zowe'"
-                                        }
-                                        sh "npm install jsonfile"
+                                        sh "cp ../zowe_licenses_full.zip zowe_licenses_full.zip"
 
                                         script { imperativeVersion = "next" }
                                         sh "npm pack @zowe/imperative@${imperativeVersion}"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -335,7 +335,7 @@ pipeline {
                                         sh "zip -r zowe-sdk.zip *"
 
                                         // Archive the zowe Python SDK
-                                        sh "mv zowe-sdk.zip ../zowe-python-sdk-${ZOWE_CLI_BUNDLE_VERSION}.zip"
+                                        sh "mv zowe-sdk.zip ../../zowe-python-sdk-${ZOWE_CLI_BUNDLE_VERSION}.zip"
 
                                         deleteDir()
                                     }
@@ -584,7 +584,7 @@ pipeline {
                         uploadSpec = """{
                         "files": [{
                             "pattern": "zowe-cli-package-next-*.zip",
-                            "target": "${targetRepository}/org/zowe/cli/zowe-cli-package/next/${targetVersion}/"
+                            "target": "${targetRepository}/org/zowe/cli/zowe-cli-package/next/"
                         }]
                         }"""
                         buildInfo = Artifactory.newBuildInfo()
@@ -595,7 +595,7 @@ pipeline {
                         uploadSpec = """{
                         "files": [{
                             "pattern": "zowe-cli-plugins-next-*.zip",
-                            "target": "${targetRepository}/org/zowe/cli/zowe-cli-plugins/next/${targetVersion}/"
+                            "target": "${targetRepository}/org/zowe/cli/zowe-cli-plugins/next/"
                         }]
                         }"""
                         buildInfo = Artifactory.newBuildInfo()
@@ -606,7 +606,7 @@ pipeline {
                         uploadSpec = """{
                         "files": [{
                             "pattern": "zowe-nodejs-sdk-next-*.zip",
-                            "target": "${targetRepository}/org/zowe/sdk/zowe-nodejs-sdk/next/${targetVersion}/"
+                            "target": "${targetRepository}/org/zowe/sdk/zowe-nodejs-sdk/next/"
                         }]
                         }"""
                         buildInfo = Artifactory.newBuildInfo()

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -164,8 +164,8 @@ pipeline {
                         ************************************************************************/
                         stage('CLI Core (LTS)') {
                             steps {
-                                dir("lts") {
-                                    timeout(time: 10, unit: 'MINUTES') {
+                                timeout(time: 10, unit: 'MINUTES') {
+                                    dir("lts") {
                                         sh "mkdir -p licenses && cd licenses && cp ../../zowe_licenses_full.zip zowe_licenses_full.zip"
 
                                         script { zoweCliVersion = "6.31.1" }
@@ -174,11 +174,11 @@ pipeline {
                                         sh "../scripts/repackage_bundle.sh *.tgz"
                                         sh "mv zowe-cli-package.zip ../zowe-cli-package-${ZOWE_CLI_BUNDLE_VERSION}.zip"
 
-                                        archiveArtifacts artifacts: "**/zowe-cli-package-${ZOWE_CLI_BUNDLE_VERSION}.zip"
-
-                                        // Remove all tgzs after bundle is archived
+                                        // Remove all tgzs after bundle has been generated
                                         sh "rm -f *.tgz"
                                     }
+
+                                    archiveArtifacts artifacts: "zowe-cli-package-${ZOWE_CLI_BUNDLE_VERSION}.zip"
                                 }
                             }
                         }
@@ -208,8 +208,8 @@ pipeline {
                         ************************************************************************/
                         stage('CLI Plugins (LTS)') {
                             steps {
-                                dir("lts") {
-                                    timeout(time: 10, unit: 'MINUTES') {
+                                timeout(time: 10, unit: 'MINUTES') {
+                                    dir("lts") {
                                         sh "mkdir -p licenses && cd licenses && cp ../../zowe_licenses_full.zip zowe_licenses_full.zip"
 
                                         sh "npm pack @zowe/db2-for-zowe-cli@4.1.0"
@@ -220,11 +220,11 @@ pipeline {
                                         sh "../scripts/repackage_bundle.sh *.tgz"
                                         sh "mv zowe-cli-package.zip ../zowe-cli-plugins-${ZOWE_CLI_BUNDLE_VERSION}.zip"
 
-                                        archiveArtifacts artifacts: "**/zowe-cli-plugins-${ZOWE_CLI_BUNDLE_VERSION}.zip"
-
-                                        // Remove all tgzs after bundle is archived
+                                        // Remove all tgzs after bundle has been generated
                                         sh "rm -f *.tgz"
                                     }
+
+                                    archiveArtifacts artifacts: "zowe-cli-plugins-${ZOWE_CLI_BUNDLE_VERSION}.zip"
                                 }
                             }
                         }
@@ -253,8 +253,8 @@ pipeline {
                         ************************************************************************/
                         stage('NodeJS SDK (LTS)') {
                             steps {
-                                dir("lts") {
-                                    timeout(time: 10, unit: 'MINUTES') {
+                                timeout(time: 10, unit: 'MINUTES') {
+                                    dir("lts") {
                                         sh "mkdir -p licenses && cd licenses && cp ../../zowe_licenses_full.zip zowe_licenses_full.zip"
 
                                         script { imperativeVersion = "4.13.1" }
@@ -275,11 +275,11 @@ pipeline {
                                         sh "../scripts/generate_typedoc.sh ${ZOWE_CLI_BUNDLE_VERSION} ${imperativeVersion} ${zoweCliVersion}" // Outputs a zowe-node-sdk-typedoc.zip
                                         sh "mv zowe-node-sdk-typedoc.zip ../zowe-nodejs-sdk-typedoc-${ZOWE_CLI_BUNDLE_VERSION}.zip"
 
-                                        archiveArtifacts artifacts: "**/zowe-nodejs-sdk*-${ZOWE_CLI_BUNDLE_VERSION}.zip"
-
-                                        // Remove all tgzs after bundle is archived
+                                        // Remove all tgzs after bundle has been generated
                                         sh "rm -f *.tgz"
                                     }
+
+                                    archiveArtifacts artifacts: "zowe-nodejs-sdk*-${ZOWE_CLI_BUNDLE_VERSION}.zip"
                                 }
                             }
                         }
@@ -306,8 +306,8 @@ pipeline {
                         ************************************************************************/
                         stage('Python SDK (LTS)') {
                             steps {
-                                dir("lts") {
-                                    timeout(time: 10, unit: 'MINUTES') {
+                                timeout(time: 10, unit: 'MINUTES') {
+                                    dir("lts") {
                                         // Download all zowe wheels into a temp folder
                                         sh "mkdir -p temp && cd temp && pip3 download zowe"
                                         sh "cd temp && mkdir -p licenses && cd licenses && curl -fs -o zowe_licenses_full.zip $ZOWE_LICENSE_ZIP_URL"
@@ -317,8 +317,9 @@ pipeline {
 
                                         // Archive the zowe Python SDK
                                         sh "mv zowe-sdk.zip ../zowe-python-sdk-${ZOWE_CLI_BUNDLE_VERSION}.zip"
-                                        archiveArtifacts artifacts: "**/zowe-python-sdk-${ZOWE_CLI_BUNDLE_VERSION}.zip"
                                     }
+
+                                    archiveArtifacts artifacts: "zowe-python-sdk-${ZOWE_CLI_BUNDLE_VERSION}.zip"
                                 }
                             }
                         }
@@ -352,8 +353,8 @@ pipeline {
                         ************************************************************************/
                         stage('CLI Core (Next)') {
                             steps {
-                                dir("next") {
-                                    timeout(time: 10, unit: 'MINUTES') {
+                                timeout(time: 10, unit: 'MINUTES') {
+                                    dir("next") {
                                         sh "mkdir -p licenses && cd licenses && cp ../../zowe_licenses_full.zip zowe_licenses_full.zip"
 
                                         script { zoweCliVersion = "next" }
@@ -363,11 +364,11 @@ pipeline {
                                         sh "../scripts/repackage_bundle.sh *.tgz"
                                         sh "mv zowe-cli-package.zip ../zowe-cli-package-${ZOWE_CLI_BUNDLE_NEXT_VERSION}.zip"
 
-                                        archiveArtifacts artifacts: "**/zowe-cli-package-${ZOWE_CLI_BUNDLE_NEXT_VERSION}.zip"
-
-                                        // Remove all tgzs after bundle is archived
+                                        // Remove all tgzs after bundle has been generated
                                         sh "rm -f *.tgz"
                                     }
+
+                                    archiveArtifacts artifacts: "zowe-cli-package-${ZOWE_CLI_BUNDLE_NEXT_VERSION}.zip"
                                 }
                             }
                         }
@@ -397,8 +398,8 @@ pipeline {
                         ************************************************************************/
                         stage('CLI Plugins (Next)') {
                             steps {
-                                dir("next") {
-                                    timeout(time: 10, unit: 'MINUTES') {
+                                timeout(time: 10, unit: 'MINUTES') {
+                                    dir("next") {
                                         sh "mkdir -p licenses && cd licenses && cp ../../zowe_licenses_full.zip zowe_licenses_full.zip"
 
                                         sh "npm pack @zowe/db2-for-zowe-cli@next"
@@ -411,11 +412,11 @@ pipeline {
                                         sh "../scripts/repackage_bundle.sh *.tgz"
                                         sh "mv zowe-cli-package.zip ../zowe-cli-plugins-${ZOWE_CLI_BUNDLE_NEXT_VERSION}.zip"
 
-                                        archiveArtifacts artifacts: "**/zowe-cli-plugins-${ZOWE_CLI_BUNDLE_NEXT_VERSION}.zip"
-
-                                        // Remove all tgzs after bundle is archived
+                                        // Remove all tgzs after bundle has been generated
                                         sh "rm -f *.tgz"
                                     }
+
+                                    archiveArtifacts artifacts: "zowe-cli-plugins-${ZOWE_CLI_BUNDLE_NEXT_VERSION}.zip"
                                 }
                             }
                         }
@@ -444,8 +445,8 @@ pipeline {
                         ************************************************************************/
                         stage('NodeJS SDK (Next)') {
                             steps {
-                                dir("next") {
-                                    timeout(time: 10, unit: 'MINUTES') {
+                                timeout(time: 10, unit: 'MINUTES') {
+                                    dir("next") {
                                         sh "mkdir -p licenses && cd licenses && cp ../../zowe_licenses_full.zip zowe_licenses_full.zip"
 
                                         script { imperativeVersion = "next" }
@@ -466,11 +467,11 @@ pipeline {
                                         sh "../scripts/generate_typedoc.sh next" // Outputs a zowe-node-sdk-typedoc.zip
                                         sh "mv zowe-node-sdk-typedoc.zip ../zowe-nodejs-sdk-typedoc-${ZOWE_CLI_BUNDLE_NEXT_VERSION}.zip"
 
-                                        archiveArtifacts artifacts: "**/zowe-nodejs-sdk*-${ZOWE_CLI_BUNDLE_NEXT_VERSION}.zip"
-
-                                        // Remove all tgzs after bundle is archived
+                                        // Remove all tgzs after bundle has been generated
                                         sh "rm -f *.tgz"
                                     }
+
+                                    archiveArtifacts artifacts: "zowe-nodejs-sdk*-${ZOWE_CLI_BUNDLE_NEXT_VERSION}.zip"
                                 }
                             }
                         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -579,13 +579,13 @@ pipeline {
                         server.publishBuildInfo buildInfo
 
                         // Next: Upload Core CLI and SCS (zowe-cli-package)
-                        def uploadSpec = """{
+                        uploadSpec = """{
                         "files": [{
                             "pattern": "zowe-cli-package-next-*.zip",
                             "target": "${targetRepository}/org/zowe/cli/zowe-cli-package/next/${targetVersion}/"
                         }]
                         }"""
-                        def buildInfo = Artifactory.newBuildInfo()
+                        buildInfo = Artifactory.newBuildInfo()
                         server.upload spec: uploadSpec, buildInfo: buildInfo
                         server.publishBuildInfo buildInfo
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -58,6 +58,7 @@ def ZOWE_ARTIFACTORY_URL = "https://zowe.jfrog.io/zowe/api/npm/npm-local-release
 * The Zowe CLI Bundle Version to deploy to Artifactory
 */
 def ZOWE_CLI_BUNDLE_VERSION = "1.22.0-SNAPSHOT"
+def ZOWE_CLI_BUNDLE_NEXT_VERSION = "2.0.0-preview-SNAPSHOT"
 def ZOWE_VERSION_NUMBER = "1.22.0"
 
 /**
@@ -89,7 +90,12 @@ def ZOWE_LICENSE_ZIP_URL = "https://zowe.jfrog.io/zowe/$ARTIFACTORY_RELEASE_REPO
 /**
 * Master branch
 */
-def MASTER_BRANCH = "master"
+def MASTER_BRANCH = "publish-next"
+
+/**
+* If true, no artifacts will be published even when branch is MASTER_BRANCH
+*/
+def DRY_RUN = true
 
 /**
 * Variables defined later in pipeline
@@ -107,230 +113,429 @@ pipeline {
     }
 
     stages {
-        /************************************************************************
-         * STAGE
-         * -----
-         * Build Zowe CLI Bundle
-         *
-         * TIMEOUT
-         * -------
-         * 10 Minutes
-         *
-         * EXECUTION CONDITIONS
-         * --------------------
-         * - Always
-         *
-         * DECRIPTION
-         * ----------
-         * Gets the latest version of the Zowe CLI and SCS plugin from Zowe
-         * Artifactory. Creates an archive with 'fat' versions of the CLI and Plugin -
-         *  dependencies are bundled.
-         *
-         * OUTPUTS
-         * -------
-         * A Zowe CLI Archive containing Zowe CLI and Zowe CLI Secure Credential Store Plugin
-         ************************************************************************/
-        stage('Create Zowe CLI Bundle') {
-            when {
-                allOf {
-                    expression {
-                        return BRANCH_NAME.equals(MASTER_BRANCH)
+        stage('Create Bundles') {
+            parallel {
+                stage('Create Bundles (LTS)') {
+                    stages {
+                        /************************************************************************
+                        * STAGE
+                        * -----
+                        * Build Zowe CLI Bundle
+                        *
+                        * TIMEOUT
+                        * -------
+                        * 10 Minutes
+                        *
+                        * EXECUTION CONDITIONS
+                        * --------------------
+                        * - Always
+                        *
+                        * DESCRIPTION
+                        * ----------
+                        * Gets the latest version of the Zowe CLI and SCS plugin from Zowe
+                        * Artifactory. Creates an archive with 'fat' versions of the CLI and Plugin -
+                        *  dependencies are bundled.
+                        *
+                        * OUTPUTS
+                        * -------
+                        * A Zowe CLI Archive containing Zowe CLI and Zowe CLI Secure Credential Store Plugin
+                        ************************************************************************/
+                        stage('CLI Core (LTS)') {
+                            when {
+                                allOf {
+                                    expression {
+                                        return BRANCH_NAME.equals(MASTER_BRANCH)
+                                    }
+                                }
+                            }
+                            steps {
+                                timeout(time: 10, unit: 'MINUTES') {
+
+                                    sh "npm set registry https://registry.npmjs.org/"
+                                    sh "npm set @zowe:registry ${ZOWE_ARTIFACTORY_URL}"
+                                    withCredentials([usernamePassword(credentialsId: ARTIFACTORY_CREDENTIALS_ID, usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD')]) {
+                                        // TODO: Consider using tooling like artifactory-download-spec to get license.zip. Post-Infrastructure migration answer.
+                                        sh "mkdir -p licenses && cd licenses && curl -fs -o zowe_licenses_full.zip $ZOWE_LICENSE_ZIP_URL"
+                                        sh "./scripts/npm_login.sh $USERNAME $PASSWORD \"$ARTIFACTORY_EMAIL\" '--registry=${ZOWE_ARTIFACTORY_URL} --scope=@zowe'"
+                                    }
+                                    sh "npm install jsonfile"
+
+                                    script { zoweCliVersion = "6.31.1" }
+                                    sh "npm pack @zowe/cli@${zoweCliVersion}"
+                                    sh "npm pack @zowe/secure-credential-store-for-zowe-cli@4.1.5"
+                                    sh "./scripts/repackage_bundle.sh *.tgz"
+                                    sh "mv zowe-cli-package.zip zowe-cli-package-${ZOWE_CLI_BUNDLE_VERSION}.zip"
+
+                                    archiveArtifacts artifacts: "zowe-cli-package-${ZOWE_CLI_BUNDLE_VERSION}.zip"
+
+                                    // Remove all tgzs after bundle is archived
+                                    sh "rm -f *.tgz"
+                                }
+                            }
+                        }
+                        /************************************************************************
+                        * STAGE
+                        * -----
+                        * Build Zowe CLI Plugins Bundle
+                        *
+                        * TIMEOUT
+                        * -------
+                        * 10 Minutes
+                        *
+                        * EXECUTION CONDITIONS
+                        * --------------------
+                        * - Always
+                        *
+                        * DESCRIPTION
+                        * ----------
+                        * Gets the latest version of the Zowe CLI Plugins from Zowe
+                        * Artifactory. Creates an archive with 'fat' versions of the Plugins -
+                        *  dependencies are bundled.
+                        *
+                        * OUTPUTS
+                        * -------
+                        * A Zowe CLI Plugins Archive containing Zowe CLI DB2 Plugin, Zowe CLI CICS Plugin,
+                        * Zowe CLI z/OS FTP Plugin, Zowe CLI IMS Plugin, and Zowe CLI MQ Plugin.
+                        ************************************************************************/
+                        stage('CLI Plugins (LTS)') {
+                            when {
+                                allOf {
+                                    expression {
+                                        return BRANCH_NAME.equals(MASTER_BRANCH)
+                                    }
+                                }
+                            }
+                            steps {
+                                timeout(time: 10, unit: 'MINUTES') {
+
+                                    sh "npm set registry https://registry.npmjs.org/"
+                                    sh "npm set @zowe:registry ${ZOWE_ARTIFACTORY_URL}"
+                                    withCredentials([usernamePassword(credentialsId: ARTIFACTORY_CREDENTIALS_ID, usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD')]) {
+                                        // TODO: Consider using tooling like artifactory-download-spec to get license.zip. Post-Infrastructure migration answer.
+                                        sh "mkdir -p licenses && cd licenses && curl -fs -o zowe_licenses_full.zip $ZOWE_LICENSE_ZIP_URL"
+                                        sh "./scripts/npm_login.sh $USERNAME $PASSWORD \"$ARTIFACTORY_EMAIL\" '--registry=${ZOWE_ARTIFACTORY_URL} --scope=@zowe'"
+                                    }
+                                    sh "npm install jsonfile"
+
+                                    sh "npm pack @zowe/db2-for-zowe-cli@4.1.0"
+                                    sh "npm pack @zowe/cics-for-zowe-cli@4.0.2"
+                                    sh "npm pack @zowe/ims-for-zowe-cli@2.0.1"
+                                    sh "npm pack @zowe/mq-for-zowe-cli@2.0.1"
+                                    sh "npm pack @zowe/zos-ftp-for-zowe-cli@1.6.0"
+                                    sh "./scripts/repackage_bundle.sh *.tgz"
+                                    sh "mv zowe-cli-package.zip zowe-cli-plugins-${ZOWE_CLI_BUNDLE_VERSION}.zip"
+
+                                    archiveArtifacts artifacts: "zowe-cli-plugins-${ZOWE_CLI_BUNDLE_VERSION}.zip"
+
+                                    // Remove all tgzs after bundle is archived
+                                    sh "rm -f *.tgz"
+                                }
+                            }
+                        }
+                        /************************************************************************
+                        * STAGE
+                        * -----
+                        * Build Zowe NodeJS SDK Bundle
+                        *
+                        * TIMEOUT
+                        * -------
+                        * 10 Minutes
+                        *
+                        * EXECUTION CONDITIONS
+                        * --------------------
+                        * - Always
+                        *
+                        * DESCRIPTION
+                        * ----------
+                        * Gets the latest version of the Zowe NodeJS SDK package from NPM
+                        * Creates an archive with 'fat' versions of the Plugins -
+                        *   dependencies are bundled.
+                        *
+                        * OUTPUTS
+                        * -------
+                        * A Zowe NodeJS SDK Archive.
+                        ************************************************************************/
+                        stage('NodeJS SDK (LTS)') {
+                            when {
+                                allOf {
+                                    expression {
+                                        return BRANCH_NAME.equals(MASTER_BRANCH)
+                                    }
+                                }
+                            }
+                            steps {
+                                timeout(time: 10, unit: 'MINUTES') {
+
+                                    sh "npm set registry https://registry.npmjs.org/"
+                                    sh "npm set @zowe:registry ${ZOWE_ARTIFACTORY_URL}"
+                                    withCredentials([usernamePassword(credentialsId: ARTIFACTORY_CREDENTIALS_ID, usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD')]) {
+                                        // TODO: Consider using tooling like artifactory-download-spec to get license.zip. Post-Infrastructure migration answer.
+                                        sh "mkdir -p licenses && cd licenses && curl -fs -o zowe_licenses_full.zip $ZOWE_LICENSE_ZIP_URL"
+                                        sh "./scripts/npm_login.sh $USERNAME $PASSWORD \"$ARTIFACTORY_EMAIL\" '--registry=${ZOWE_ARTIFACTORY_URL} --scope=@zowe'"
+                                    }
+                                    sh "npm install jsonfile"
+
+                                    script { imperativeVersion = "4.13.1" }
+                                    sh "npm pack @zowe/imperative@${imperativeVersion}"
+                                    sh "npm pack @zowe/core-for-zowe-sdk@6.31.1"
+                                    sh "npm pack @zowe/provisioning-for-zowe-sdk@6.31.1"
+                                    sh "npm pack @zowe/zos-console-for-zowe-sdk@6.31.1"
+                                    sh "npm pack @zowe/zos-files-for-zowe-sdk@6.31.1"
+                                    sh "npm pack @zowe/zos-jobs-for-zowe-sdk@6.31.1"
+                                    sh "npm pack @zowe/zos-tso-for-zowe-sdk@6.31.1"
+                                    sh "npm pack @zowe/zos-uss-for-zowe-sdk@6.31.1"
+                                    sh "npm pack @zowe/zos-workflows-for-zowe-sdk@6.31.1"
+                                    sh "npm pack @zowe/zosmf-for-zowe-sdk@6.31.1"
+
+                                    sh "./scripts/repackage_bundle.sh *.tgz" // Outputs a zowe-cli-package.zip
+                                    sh "mv zowe-cli-package.zip zowe-nodejs-sdk-${ZOWE_CLI_BUNDLE_VERSION}.zip"
+
+                                    sh "./scripts/generate_typedoc.sh ${ZOWE_CLI_BUNDLE_VERSION} ${imperativeVersion} ${zoweCliVersion}" // Outputs a zowe-node-sdk-typedoc.zip
+                                    sh "mv zowe-node-sdk-typedoc.zip zowe-nodejs-sdk-typedoc-${ZOWE_CLI_BUNDLE_VERSION}.zip"
+
+                                    archiveArtifacts artifacts: "zowe-nodejs-sdk*-${ZOWE_CLI_BUNDLE_VERSION}.zip"
+
+                                    // Remove all tgzs after bundle is archived
+                                    sh "rm -f *.tgz"
+                                }
+                            }
+                        }
+                        /************************************************************************
+                        * STAGE
+                        * -----
+                        * Build Zowe Python SDK Bundle
+                        *
+                        * TIMEOUT
+                        * -------
+                        * 10 Minutes
+                        *
+                        * EXECUTION CONDITIONS
+                        * --------------------
+                        * - Always
+                        *
+                        * DESCRIPTION
+                        * ----------
+                        * Gets the latest version of the Zowe Python SDK package from pypi.org
+                        *
+                        * OUTPUTS
+                        * -------
+                        * A Zowe Python SDK Archive.
+                        ************************************************************************/
+                        stage('Python SDK (LTS)') {
+                            when {
+                                allOf {
+                                    expression {
+                                        return BRANCH_NAME.equals(MASTER_BRANCH)
+                                    }
+                                }
+                            }
+                            steps {
+                                timeout(time: 10, unit: 'MINUTES') {
+                                    // Download all zowe wheels into a temp folder
+                                    sh "mkdir -p temp && cd temp && pip3 download zowe"
+                                    sh "cd temp && mkdir -p licenses && cd licenses && curl -fs -o zowe_licenses_full.zip $ZOWE_LICENSE_ZIP_URL"
+
+                                    // Zip all zowe wheels into a zowe-sdk.zip
+                                    sh "cd temp && zip -r zowe-sdk.zip * && mv zowe-sdk.zip ../ && rm -rf temp"
+
+                                    // Archive the zowe Python SDK
+                                    sh "mv zowe-sdk.zip zowe-python-sdk-${ZOWE_CLI_BUNDLE_VERSION}.zip"
+                                    archiveArtifacts artifacts: "zowe-python-sdk-${ZOWE_CLI_BUNDLE_VERSION}.zip"
+                                }
+                            }
+                        }
                     }
                 }
-            }
-            steps {
-                timeout(time: 10, unit: 'MINUTES') {
 
-                    sh "npm set registry https://registry.npmjs.org/"
-                    sh "npm set @zowe:registry ${ZOWE_ARTIFACTORY_URL}"
-                    withCredentials([usernamePassword(credentialsId: ARTIFACTORY_CREDENTIALS_ID, usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD')]) {
-                        // TODO: Consider using tooling like artifactory-download-spec to get license.zip. Post-Infrastructure migration answer.
-                        sh "mkdir -p licenses && cd licenses && curl -fs -o zowe_licenses_full.zip $ZOWE_LICENSE_ZIP_URL"
-                        sh "./scripts/npm_login.sh $USERNAME $PASSWORD \"$ARTIFACTORY_EMAIL\" '--registry=${ZOWE_ARTIFACTORY_URL} --scope=@zowe'"
+                stage('Create Bundles (Next)') {
+                    stages {
+                        /************************************************************************
+                        * STAGE
+                        * -----
+                        * Build Zowe CLI Bundle
+                        *
+                        * TIMEOUT
+                        * -------
+                        * 10 Minutes
+                        *
+                        * EXECUTION CONDITIONS
+                        * --------------------
+                        * - Always
+                        *
+                        * DESCRIPTION
+                        * ----------
+                        * Gets the latest version of the Zowe CLI and SCS plugin from Zowe
+                        * Artifactory. Creates an archive with 'fat' versions of the CLI and Plugin -
+                        *  dependencies are bundled.
+                        *
+                        * OUTPUTS
+                        * -------
+                        * A Zowe CLI Archive containing Zowe CLI and Zowe CLI Secure Credential Store Plugin
+                        ************************************************************************/
+                        stage('CLI Core (Next)') {
+                            when {
+                                allOf {
+                                    expression {
+                                        return BRANCH_NAME.equals(MASTER_BRANCH)
+                                    }
+                                }
+                            }
+                            steps {
+                                timeout(time: 10, unit: 'MINUTES') {
+
+                                    sh "npm set registry https://registry.npmjs.org/"
+                                    sh "npm set @zowe:registry ${ZOWE_ARTIFACTORY_URL}"
+                                    withCredentials([usernamePassword(credentialsId: ARTIFACTORY_CREDENTIALS_ID, usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD')]) {
+                                        // TODO: Consider using tooling like artifactory-download-spec to get license.zip. Post-Infrastructure migration answer.
+                                        sh "mkdir -p licenses && cd licenses && curl -fs -o zowe_licenses_full.zip $ZOWE_LICENSE_ZIP_URL"
+                                        sh "./scripts/npm_login.sh $USERNAME $PASSWORD \"$ARTIFACTORY_EMAIL\" '--registry=${ZOWE_ARTIFACTORY_URL} --scope=@zowe'"
+                                    }
+                                    sh "npm install jsonfile"
+
+                                    script { zoweCliVersion = "next" }
+                                    sh "npm pack @zowe/cli@${zoweCliVersion}"
+                                    // SCS plug-in deprecated in @next
+                                    // sh "npm pack @zowe/secure-credential-store-for-zowe-cli@4.1.5"
+                                    sh "./scripts/repackage_bundle.sh *.tgz"
+                                    sh "mv zowe-cli-package.zip zowe-cli-package-${ZOWE_CLI_BUNDLE_NEXT_VERSION}.zip"
+
+                                    archiveArtifacts artifacts: "zowe-cli-package-${ZOWE_CLI_BUNDLE_NEXT_VERSION}.zip"
+
+                                    // Remove all tgzs after bundle is archived
+                                    sh "rm -f *.tgz"
+                                }
+                            }
+                        }
+                        /************************************************************************
+                        * STAGE
+                        * -----
+                        * Build Zowe CLI Plugins Bundle
+                        *
+                        * TIMEOUT
+                        * -------
+                        * 10 Minutes
+                        *
+                        * EXECUTION CONDITIONS
+                        * --------------------
+                        * - Always
+                        *
+                        * DESCRIPTION
+                        * ----------
+                        * Gets the latest version of the Zowe CLI Plugins from Zowe
+                        * Artifactory. Creates an archive with 'fat' versions of the Plugins -
+                        *  dependencies are bundled.
+                        *
+                        * OUTPUTS
+                        * -------
+                        * A Zowe CLI Plugins Archive containing Zowe CLI DB2 Plugin, Zowe CLI CICS Plugin,
+                        * Zowe CLI z/OS FTP Plugin, Zowe CLI IMS Plugin, and Zowe CLI MQ Plugin.
+                        ************************************************************************/
+                        stage('CLI Plugins (Next)') {
+                            when {
+                                allOf {
+                                    expression {
+                                        return BRANCH_NAME.equals(MASTER_BRANCH)
+                                    }
+                                }
+                            }
+                            steps {
+                                timeout(time: 10, unit: 'MINUTES') {
+
+                                    sh "npm set registry https://registry.npmjs.org/"
+                                    sh "npm set @zowe:registry ${ZOWE_ARTIFACTORY_URL}"
+                                    withCredentials([usernamePassword(credentialsId: ARTIFACTORY_CREDENTIALS_ID, usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD')]) {
+                                        // TODO: Consider using tooling like artifactory-download-spec to get license.zip. Post-Infrastructure migration answer.
+                                        sh "mkdir -p licenses && cd licenses && curl -fs -o zowe_licenses_full.zip $ZOWE_LICENSE_ZIP_URL"
+                                        sh "./scripts/npm_login.sh $USERNAME $PASSWORD \"$ARTIFACTORY_EMAIL\" '--registry=${ZOWE_ARTIFACTORY_URL} --scope=@zowe'"
+                                    }
+                                    sh "npm install jsonfile"
+
+                                    sh "npm pack @zowe/db2-for-zowe-cli@next"
+                                    sh "npm pack @zowe/cics-for-zowe-cli@next"
+                                    sh "npm pack @zowe/ims-for-zowe-cli@next"
+                                    sh "npm pack @zowe/mq-for-zowe-cli@next"
+                                    // FTP plug-in doesn't have @next release published yet
+                                    // We bundle @latest since it's compatible with team config
+                                    sh "npm pack @zowe/zos-ftp-for-zowe-cli"
+                                    sh "./scripts/repackage_bundle.sh *.tgz"
+                                    sh "mv zowe-cli-package.zip zowe-cli-plugins-${ZOWE_CLI_BUNDLE_NEXT_VERSION}.zip"
+
+                                    archiveArtifacts artifacts: "zowe-cli-plugins-${ZOWE_CLI_BUNDLE_NEXT_VERSION}.zip"
+
+                                    // Remove all tgzs after bundle is archived
+                                    sh "rm -f *.tgz"
+                                }
+                            }
+                        }
+                        /************************************************************************
+                        * STAGE
+                        * -----
+                        * Build Zowe NodeJS SDK Bundle
+                        *
+                        * TIMEOUT
+                        * -------
+                        * 10 Minutes
+                        *
+                        * EXECUTION CONDITIONS
+                        * --------------------
+                        * - Always
+                        *
+                        * DESCRIPTION
+                        * ----------
+                        * Gets the latest version of the Zowe NodeJS SDK package from NPM
+                        * Creates an archive with 'fat' versions of the Plugins -
+                        *   dependencies are bundled.
+                        *
+                        * OUTPUTS
+                        * -------
+                        * A Zowe NodeJS SDK Archive.
+                        ************************************************************************/
+                        stage('NodeJS SDK (Next)') {
+                            when {
+                                allOf {
+                                    expression {
+                                        return BRANCH_NAME.equals(MASTER_BRANCH)
+                                    }
+                                }
+                            }
+                            steps {
+                                timeout(time: 10, unit: 'MINUTES') {
+
+                                    sh "npm set registry https://registry.npmjs.org/"
+                                    sh "npm set @zowe:registry ${ZOWE_ARTIFACTORY_URL}"
+                                    withCredentials([usernamePassword(credentialsId: ARTIFACTORY_CREDENTIALS_ID, usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD')]) {
+                                        // TODO: Consider using tooling like artifactory-download-spec to get license.zip. Post-Infrastructure migration answer.
+                                        sh "mkdir -p licenses && cd licenses && curl -fs -o zowe_licenses_full.zip $ZOWE_LICENSE_ZIP_URL"
+                                        sh "./scripts/npm_login.sh $USERNAME $PASSWORD \"$ARTIFACTORY_EMAIL\" '--registry=${ZOWE_ARTIFACTORY_URL} --scope=@zowe'"
+                                    }
+                                    sh "npm install jsonfile"
+
+                                    script { imperativeVersion = "next" }
+                                    sh "npm pack @zowe/imperative@${imperativeVersion}"
+                                    sh "npm pack @zowe/core-for-zowe-sdk@next"
+                                    sh "npm pack @zowe/provisioning-for-zowe-sdk@next"
+                                    sh "npm pack @zowe/zos-console-for-zowe-sdk@next"
+                                    sh "npm pack @zowe/zos-files-for-zowe-sdk@next"
+                                    sh "npm pack @zowe/zos-jobs-for-zowe-sdk@next"
+                                    sh "npm pack @zowe/zos-tso-for-zowe-sdk@next"
+                                    sh "npm pack @zowe/zos-uss-for-zowe-sdk@next"
+                                    sh "npm pack @zowe/zos-workflows-for-zowe-sdk@next"
+                                    sh "npm pack @zowe/zosmf-for-zowe-sdk@next"
+
+                                    sh "./scripts/repackage_bundle.sh *.tgz" // Outputs a zowe-cli-package.zip
+                                    sh "mv zowe-cli-package.zip zowe-nodejs-sdk-${ZOWE_CLI_BUNDLE_NEXT_VERSION}.zip"
+
+                                    sh "./scripts/generate_typedoc.sh next" // Outputs a zowe-node-sdk-typedoc.zip
+                                    sh "mv zowe-node-sdk-typedoc.zip zowe-nodejs-sdk-typedoc-${ZOWE_CLI_BUNDLE_NEXT_VERSION}.zip"
+
+                                    archiveArtifacts artifacts: "zowe-nodejs-sdk*-${ZOWE_CLI_BUNDLE_NEXT_VERSION}.zip"
+
+                                    // Remove all tgzs after bundle is archived
+                                    sh "rm -f *.tgz"
+                                }
+                            }
+                        }
                     }
-                    sh "npm install jsonfile"
-
-                    script { zoweCliVersion = "6.31.1" }
-                    sh "npm pack @zowe/cli@${zoweCliVersion}"
-                    sh "npm pack @zowe/secure-credential-store-for-zowe-cli@4.1.5"
-                    sh "./scripts/repackage_bundle.sh *.tgz"
-                    sh "mv zowe-cli-package.zip zowe-cli-package-${ZOWE_CLI_BUNDLE_VERSION}.zip"
-
-                    archiveArtifacts artifacts: "zowe-cli-package-${ZOWE_CLI_BUNDLE_VERSION}.zip"
-
-                    // Remove all tgzs after bundle is archived
-                    sh "rm -f *.tgz"
-                }
-            }
-        }
-        /************************************************************************
-         * STAGE
-         * -----
-         * Build Zowe CLI Plugins Bundle
-         *
-         * TIMEOUT
-         * -------
-         * 10 Minutes
-         *
-         * EXECUTION CONDITIONS
-         * --------------------
-         * - Always
-         *
-         * DECRIPTION
-         * ----------
-         * Gets the latest version of the Zowe CLI Plugins from Zowe
-         * Artifactory. Creates an archive with 'fat' versions of the Plugins -
-         *  dependencies are bundled.
-         *
-         * OUTPUTS
-         * -------
-         * A Zowe CLI Plugins Archive containing Zowe CLI DB2 Plugin, Zowe CLI CICS Plugin,
-         * Zowe CLI z/OS FTP Plugin, Zowe CLI IMS Plugin, and Zowe CLI MQ Plugin.
-         ************************************************************************/
-        stage('Create Zowe CLI Plugins Bundle') {
-            when {
-                allOf {
-                    expression {
-                        return BRANCH_NAME.equals(MASTER_BRANCH)
-                    }
-                }
-            }
-            steps {
-                timeout(time: 10, unit: 'MINUTES') {
-
-                    sh "npm set registry https://registry.npmjs.org/"
-                    sh "npm set @zowe:registry ${ZOWE_ARTIFACTORY_URL}"
-                    withCredentials([usernamePassword(credentialsId: ARTIFACTORY_CREDENTIALS_ID, usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD')]) {
-                        // TODO: Consider using tooling like artifactory-download-spec to get license.zip. Post-Infrastructure migration answer.
-                        sh "mkdir -p licenses && cd licenses && curl -fs -o zowe_licenses_full.zip $ZOWE_LICENSE_ZIP_URL"
-                        sh "./scripts/npm_login.sh $USERNAME $PASSWORD \"$ARTIFACTORY_EMAIL\" '--registry=${ZOWE_ARTIFACTORY_URL} --scope=@zowe'"
-                    }
-                    sh "npm install jsonfile"
-
-                    sh "npm pack @zowe/db2-for-zowe-cli@4.1.0"
-                    sh "npm pack @zowe/cics-for-zowe-cli@4.0.2"
-                    sh "npm pack @zowe/ims-for-zowe-cli@2.0.1"
-                    sh "npm pack @zowe/mq-for-zowe-cli@2.0.1"
-                    sh "npm pack @zowe/zos-ftp-for-zowe-cli@1.6.0"
-                    sh "./scripts/repackage_bundle.sh *.tgz"
-                    sh "mv zowe-cli-package.zip zowe-cli-plugins-${ZOWE_CLI_BUNDLE_VERSION}.zip"
-
-                    archiveArtifacts artifacts: "zowe-cli-plugins-${ZOWE_CLI_BUNDLE_VERSION}.zip"
-
-                    // Remove all tgzs after bundle is archived
-                    sh "rm -f *.tgz"
-                }
-            }
-        }
-        /************************************************************************
-         * STAGE
-         * -----
-         * Build Zowe NodeJS SDK Bundle
-         *
-         * TIMEOUT
-         * -------
-         * 10 Minutes
-         *
-         * EXECUTION CONDITIONS
-         * --------------------
-         * - Always
-         *
-         * DECRIPTION
-         * ----------
-         * Gets the latest version of the Zowe NodeJS SDK package from NPM
-         * Creates an archive with 'fat' versions of the Plugins -
-         *   dependencies are bundled.
-         *
-         * OUTPUTS
-         * -------
-         * A Zowe NodeJS SDK Archive.
-         ************************************************************************/
-        stage('Create Zowe NodeJS SDK Bundle') {
-            when {
-                allOf {
-                    expression {
-                        return BRANCH_NAME.equals(MASTER_BRANCH)
-                    }
-                }
-            }
-            steps {
-                timeout(time: 10, unit: 'MINUTES') {
-
-                    sh "npm set registry https://registry.npmjs.org/"
-                    sh "npm set @zowe:registry ${ZOWE_ARTIFACTORY_URL}"
-                    withCredentials([usernamePassword(credentialsId: ARTIFACTORY_CREDENTIALS_ID, usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD')]) {
-                        // TODO: Consider using tooling like artifactory-download-spec to get license.zip. Post-Infrastructure migration answer.
-                        sh "mkdir -p licenses && cd licenses && curl -fs -o zowe_licenses_full.zip $ZOWE_LICENSE_ZIP_URL"
-                        sh "./scripts/npm_login.sh $USERNAME $PASSWORD \"$ARTIFACTORY_EMAIL\" '--registry=${ZOWE_ARTIFACTORY_URL} --scope=@zowe'"
-                    }
-                    sh "npm install jsonfile"
-
-                    script { imperativeVersion = "4.13.1" }
-                    sh "npm pack @zowe/imperative@${imperativeVersion}"
-                    sh "npm pack @zowe/core-for-zowe-sdk@6.31.1"
-                    sh "npm pack @zowe/provisioning-for-zowe-sdk@6.31.1"
-                    sh "npm pack @zowe/zos-console-for-zowe-sdk@6.31.1"
-                    sh "npm pack @zowe/zos-files-for-zowe-sdk@6.31.1"
-                    sh "npm pack @zowe/zos-jobs-for-zowe-sdk@6.31.1"
-                    sh "npm pack @zowe/zos-tso-for-zowe-sdk@6.31.1"
-                    sh "npm pack @zowe/zos-uss-for-zowe-sdk@6.31.1"
-                    sh "npm pack @zowe/zos-workflows-for-zowe-sdk@6.31.1"
-                    sh "npm pack @zowe/zosmf-for-zowe-sdk@6.31.1"
-
-                    sh "./scripts/repackage_bundle.sh *.tgz" // Outputs a zowe-cli-package.zip
-                    sh "mv zowe-cli-package.zip zowe-nodejs-sdk-${ZOWE_CLI_BUNDLE_VERSION}.zip"
-
-                    sh "./scripts/generate_typedoc.sh ${ZOWE_CLI_BUNDLE_VERSION} ${imperativeVersion} ${zoweCliVersion}" // Outputs a zowe-node-sdk-typedoc.zip
-                    sh "mv zowe-node-sdk-typedoc.zip zowe-nodejs-sdk-typedoc-${ZOWE_CLI_BUNDLE_VERSION}.zip"
-
-                    archiveArtifacts artifacts: "zowe-nodejs-sdk*-${ZOWE_CLI_BUNDLE_VERSION}.zip"
-
-                    // Remove all tgzs after bundle is archived
-                    sh "rm -f *.tgz"
-                }
-            }
-        }
-        /************************************************************************
-         * STAGE
-         * -----
-         * Build Zowe Python SDK Bundle
-         *
-         * TIMEOUT
-         * -------
-         * 10 Minutes
-         *
-         * EXECUTION CONDITIONS
-         * --------------------
-         * - Always
-         *
-         * DECRIPTION
-         * ----------
-         * Gets the latest version of the Zowe Python SDK package from pypi.org
-         *
-         * OUTPUTS
-         * -------
-         * A Zowe Python SDK Archive.
-         ************************************************************************/
-        stage('Create Zowe Python SDK Bundle') {
-            when {
-                allOf {
-                    expression {
-                        return BRANCH_NAME.equals(MASTER_BRANCH)
-                    }
-                }
-            }
-            steps {
-                timeout(time: 10, unit: 'MINUTES') {
-                    // Download all zowe wheels into a temp folder
-                    sh "mkdir -p temp && cd temp && pip3 download zowe"
-                    sh "cd temp && mkdir -p licenses && cd licenses && curl -fs -o zowe_licenses_full.zip $ZOWE_LICENSE_ZIP_URL"
-
-                    // Zip all zowe wheels into a zowe-sdk.zip
-                    sh "cd temp && zip -r zowe-sdk.zip * && mv zowe-sdk.zip ../ && rm -rf temp"
-
-                    // Archive the zowe Python SDK
-                    sh "mv zowe-sdk.zip zowe-python-sdk-${ZOWE_CLI_BUNDLE_VERSION}.zip"
-                    archiveArtifacts artifacts: "zowe-python-sdk-${ZOWE_CLI_BUNDLE_VERSION}.zip"
                 }
             }
         }
@@ -347,7 +552,7 @@ pipeline {
         * --------------------
         * - Always
         *
-        * DECRIPTION
+        * DESCRIPTION
         * ----------
         * Take the bundled zip from prior step, and upload it to Artifactory.
         * Working versions will be deployed as SNAPSHOTS, and release versions as semantic
@@ -361,7 +566,7 @@ pipeline {
             when {
                 allOf {
                     expression {
-                        return BRANCH_NAME.equals(MASTER_BRANCH)
+                        return BRANCH_NAME.equals(MASTER_BRANCH) && !DRY_RUN
                     }
                 }
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -93,7 +93,8 @@ def ZOWE_LICENSE_ZIP_URL = "https://zowe.jfrog.io/zowe/$ARTIFACTORY_RELEASE_REPO
 def MASTER_BRANCH = "master"
 
 /**
-* If true, the pipeline will run on any branch without publishing artifacts
+* If true, the pipeline will run on any branch without publishing artifacts.
+* The default value is true for PR builds, and false otherwise.
 */
 def DRY_RUN = env.CHANGE_ID != null
 
@@ -375,8 +376,7 @@ pipeline {
                                     dir("next") {
                                         sh "mkdir -p licenses && cd licenses && cp ../../zowe_licenses_full.zip zowe_licenses_full.zip"
 
-                                        script { zoweCliVersion = "next" }
-                                        sh "npm pack @zowe/cli@${zoweCliVersion}"
+                                        sh "npm pack @zowe/cli@next"
                                         // SCS plug-in deprecated in @next
                                         // sh "npm pack @zowe/secure-credential-store-for-zowe-cli@4.1.5"
                                         sh "../scripts/repackage_bundle.sh *.tgz"
@@ -467,8 +467,7 @@ pipeline {
                                     dir("next") {
                                         sh "mkdir -p licenses && cd licenses && cp ../../zowe_licenses_full.zip zowe_licenses_full.zip"
 
-                                        script { imperativeVersion = "next" }
-                                        sh "npm pack @zowe/imperative@${imperativeVersion}"
+                                        sh "npm pack @zowe/imperative@next"
                                         sh "npm pack @zowe/core-for-zowe-sdk@next"
                                         sh "npm pack @zowe/provisioning-for-zowe-sdk@next"
                                         sh "npm pack @zowe/zos-console-for-zowe-sdk@next"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -326,16 +326,18 @@ pipeline {
                         stage('Python SDK (LTS)') {
                             steps {
                                 timeout(time: 10, unit: 'MINUTES') {
-                                    dir("lts") {
+                                    dir("lts/temp") {
                                         // Download all zowe wheels into a temp folder
-                                        sh "mkdir -p temp && cd temp && pip3 download zowe"
-                                        sh "cd temp && mkdir -p licenses && cd licenses && curl -fs -o zowe_licenses_full.zip $ZOWE_LICENSE_ZIP_URL"
+                                        sh "pip3 download zowe"
+                                        sh "mkdir -p licenses && cd licenses && curl -fs -o zowe_licenses_full.zip $ZOWE_LICENSE_ZIP_URL"
 
                                         // Zip all zowe wheels into a zowe-sdk.zip
-                                        sh "cd temp && zip -r zowe-sdk.zip * && mv zowe-sdk.zip ../ && rm -rf temp"
+                                        sh "zip -r zowe-sdk.zip *"
 
                                         // Archive the zowe Python SDK
                                         sh "mv zowe-sdk.zip ../zowe-python-sdk-${ZOWE_CLI_BUNDLE_VERSION}.zip"
+
+                                        deleteDir()
                                     }
 
                                     archiveArtifacts artifacts: "zowe-python-sdk-${ZOWE_CLI_BUNDLE_VERSION}.zip"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -114,14 +114,18 @@ pipeline {
 
     stages {
         stage('Setup') {
-            sh "npm set registry https://registry.npmjs.org/"
-            sh "npm set @zowe:registry ${ZOWE_ARTIFACTORY_URL}"
-            withCredentials([usernamePassword(credentialsId: ARTIFACTORY_CREDENTIALS_ID, usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD')]) {
-                // TODO: Consider using tooling like artifactory-download-spec to get license.zip. Post-Infrastructure migration answer.
-                sh "mkdir -p licenses && cd licenses && curl -fs -o zowe_licenses_full.zip $ZOWE_LICENSE_ZIP_URL"
-                sh "../scripts/npm_login.sh $USERNAME $PASSWORD \"$ARTIFACTORY_EMAIL\" '--registry=${ZOWE_ARTIFACTORY_URL} --scope=@zowe'"
+            steps {
+                timeout(time: 5, unit: 'MINUTES') {
+                    sh "npm set registry https://registry.npmjs.org/"
+                    sh "npm set @zowe:registry ${ZOWE_ARTIFACTORY_URL}"
+                    withCredentials([usernamePassword(credentialsId: ARTIFACTORY_CREDENTIALS_ID, usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD')]) {
+                        // TODO: Consider using tooling like artifactory-download-spec to get license.zip. Post-Infrastructure migration answer.
+                        sh "mkdir -p licenses && cd licenses && curl -fs -o zowe_licenses_full.zip $ZOWE_LICENSE_ZIP_URL"
+                        sh "../scripts/npm_login.sh $USERNAME $PASSWORD \"$ARTIFACTORY_EMAIL\" '--registry=${ZOWE_ARTIFACTORY_URL} --scope=@zowe'"
+                    }
+                    sh "npm install jsonfile"
+                }
             }
-            sh "npm install jsonfile"
         }
         stage('Create Bundles') {
             when {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -156,14 +156,14 @@ pipeline {
                                         withCredentials([usernamePassword(credentialsId: ARTIFACTORY_CREDENTIALS_ID, usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD')]) {
                                             // TODO: Consider using tooling like artifactory-download-spec to get license.zip. Post-Infrastructure migration answer.
                                             sh "mkdir -p licenses && cd licenses && curl -fs -o zowe_licenses_full.zip $ZOWE_LICENSE_ZIP_URL"
-                                            sh "./scripts/npm_login.sh $USERNAME $PASSWORD \"$ARTIFACTORY_EMAIL\" '--registry=${ZOWE_ARTIFACTORY_URL} --scope=@zowe'"
+                                            sh "../scripts/npm_login.sh $USERNAME $PASSWORD \"$ARTIFACTORY_EMAIL\" '--registry=${ZOWE_ARTIFACTORY_URL} --scope=@zowe'"
                                         }
                                         sh "npm install jsonfile"
 
                                         script { zoweCliVersion = "6.31.1" }
                                         sh "npm pack @zowe/cli@${zoweCliVersion}"
                                         sh "npm pack @zowe/secure-credential-store-for-zowe-cli@4.1.5"
-                                        sh "./scripts/repackage_bundle.sh *.tgz"
+                                        sh "../scripts/repackage_bundle.sh *.tgz"
                                         sh "mv zowe-cli-package.zip ../zowe-cli-package-${ZOWE_CLI_BUNDLE_VERSION}.zip"
 
                                         archiveArtifacts artifacts: "../zowe-cli-package-${ZOWE_CLI_BUNDLE_VERSION}.zip"
@@ -214,7 +214,7 @@ pipeline {
                                         withCredentials([usernamePassword(credentialsId: ARTIFACTORY_CREDENTIALS_ID, usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD')]) {
                                             // TODO: Consider using tooling like artifactory-download-spec to get license.zip. Post-Infrastructure migration answer.
                                             sh "mkdir -p licenses && cd licenses && curl -fs -o zowe_licenses_full.zip $ZOWE_LICENSE_ZIP_URL"
-                                            sh "./scripts/npm_login.sh $USERNAME $PASSWORD \"$ARTIFACTORY_EMAIL\" '--registry=${ZOWE_ARTIFACTORY_URL} --scope=@zowe'"
+                                            sh "../scripts/npm_login.sh $USERNAME $PASSWORD \"$ARTIFACTORY_EMAIL\" '--registry=${ZOWE_ARTIFACTORY_URL} --scope=@zowe'"
                                         }
                                         sh "npm install jsonfile"
 
@@ -223,7 +223,7 @@ pipeline {
                                         sh "npm pack @zowe/ims-for-zowe-cli@2.0.1"
                                         sh "npm pack @zowe/mq-for-zowe-cli@2.0.1"
                                         sh "npm pack @zowe/zos-ftp-for-zowe-cli@1.6.0"
-                                        sh "./scripts/repackage_bundle.sh *.tgz"
+                                        sh "../scripts/repackage_bundle.sh *.tgz"
                                         sh "mv zowe-cli-package.zip ../zowe-cli-plugins-${ZOWE_CLI_BUNDLE_VERSION}.zip"
 
                                         archiveArtifacts artifacts: "../zowe-cli-plugins-${ZOWE_CLI_BUNDLE_VERSION}.zip"
@@ -273,7 +273,7 @@ pipeline {
                                         withCredentials([usernamePassword(credentialsId: ARTIFACTORY_CREDENTIALS_ID, usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD')]) {
                                             // TODO: Consider using tooling like artifactory-download-spec to get license.zip. Post-Infrastructure migration answer.
                                             sh "mkdir -p licenses && cd licenses && curl -fs -o zowe_licenses_full.zip $ZOWE_LICENSE_ZIP_URL"
-                                            sh "./scripts/npm_login.sh $USERNAME $PASSWORD \"$ARTIFACTORY_EMAIL\" '--registry=${ZOWE_ARTIFACTORY_URL} --scope=@zowe'"
+                                            sh "../scripts/npm_login.sh $USERNAME $PASSWORD \"$ARTIFACTORY_EMAIL\" '--registry=${ZOWE_ARTIFACTORY_URL} --scope=@zowe'"
                                         }
                                         sh "npm install jsonfile"
 
@@ -289,10 +289,10 @@ pipeline {
                                         sh "npm pack @zowe/zos-workflows-for-zowe-sdk@6.31.1"
                                         sh "npm pack @zowe/zosmf-for-zowe-sdk@6.31.1"
 
-                                        sh "./scripts/repackage_bundle.sh *.tgz" // Outputs a zowe-cli-package.zip
+                                        sh "../scripts/repackage_bundle.sh *.tgz" // Outputs a zowe-cli-package.zip
                                         sh "mv zowe-cli-package.zip ../zowe-nodejs-sdk-${ZOWE_CLI_BUNDLE_VERSION}.zip"
 
-                                        sh "./scripts/generate_typedoc.sh ${ZOWE_CLI_BUNDLE_VERSION} ${imperativeVersion} ${zoweCliVersion}" // Outputs a zowe-node-sdk-typedoc.zip
+                                        sh "../scripts/generate_typedoc.sh ${ZOWE_CLI_BUNDLE_VERSION} ${imperativeVersion} ${zoweCliVersion}" // Outputs a zowe-node-sdk-typedoc.zip
                                         sh "mv zowe-node-sdk-typedoc.zip ../zowe-nodejs-sdk-typedoc-${ZOWE_CLI_BUNDLE_VERSION}.zip"
 
                                         archiveArtifacts artifacts: "../zowe-nodejs-sdk*-${ZOWE_CLI_BUNDLE_VERSION}.zip"
@@ -393,7 +393,7 @@ pipeline {
                                         withCredentials([usernamePassword(credentialsId: ARTIFACTORY_CREDENTIALS_ID, usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD')]) {
                                             // TODO: Consider using tooling like artifactory-download-spec to get license.zip. Post-Infrastructure migration answer.
                                             sh "mkdir -p licenses && cd licenses && curl -fs -o zowe_licenses_full.zip $ZOWE_LICENSE_ZIP_URL"
-                                            sh "./scripts/npm_login.sh $USERNAME $PASSWORD \"$ARTIFACTORY_EMAIL\" '--registry=${ZOWE_ARTIFACTORY_URL} --scope=@zowe'"
+                                            sh "../scripts/npm_login.sh $USERNAME $PASSWORD \"$ARTIFACTORY_EMAIL\" '--registry=${ZOWE_ARTIFACTORY_URL} --scope=@zowe'"
                                         }
                                         sh "npm install jsonfile"
 
@@ -401,7 +401,7 @@ pipeline {
                                         sh "npm pack @zowe/cli@${zoweCliVersion}"
                                         // SCS plug-in deprecated in @next
                                         // sh "npm pack @zowe/secure-credential-store-for-zowe-cli@4.1.5"
-                                        sh "./scripts/repackage_bundle.sh *.tgz"
+                                        sh "../scripts/repackage_bundle.sh *.tgz"
                                         sh "mv zowe-cli-package.zip ../zowe-cli-package-${ZOWE_CLI_BUNDLE_NEXT_VERSION}.zip"
 
                                         archiveArtifacts artifacts: "../zowe-cli-package-${ZOWE_CLI_BUNDLE_NEXT_VERSION}.zip"
@@ -452,7 +452,7 @@ pipeline {
                                         withCredentials([usernamePassword(credentialsId: ARTIFACTORY_CREDENTIALS_ID, usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD')]) {
                                             // TODO: Consider using tooling like artifactory-download-spec to get license.zip. Post-Infrastructure migration answer.
                                             sh "mkdir -p licenses && cd licenses && curl -fs -o zowe_licenses_full.zip $ZOWE_LICENSE_ZIP_URL"
-                                            sh "./scripts/npm_login.sh $USERNAME $PASSWORD \"$ARTIFACTORY_EMAIL\" '--registry=${ZOWE_ARTIFACTORY_URL} --scope=@zowe'"
+                                            sh "../scripts/npm_login.sh $USERNAME $PASSWORD \"$ARTIFACTORY_EMAIL\" '--registry=${ZOWE_ARTIFACTORY_URL} --scope=@zowe'"
                                         }
                                         sh "npm install jsonfile"
 
@@ -463,7 +463,7 @@ pipeline {
                                         // FTP plug-in doesn't have @next release published yet
                                         // We bundle @latest since it's compatible with team config
                                         sh "npm pack @zowe/zos-ftp-for-zowe-cli"
-                                        sh "./scripts/repackage_bundle.sh *.tgz"
+                                        sh "../scripts/repackage_bundle.sh *.tgz"
                                         sh "mv zowe-cli-package.zip ../zowe-cli-plugins-${ZOWE_CLI_BUNDLE_NEXT_VERSION}.zip"
 
                                         archiveArtifacts artifacts: "../zowe-cli-plugins-${ZOWE_CLI_BUNDLE_NEXT_VERSION}.zip"
@@ -513,7 +513,7 @@ pipeline {
                                         withCredentials([usernamePassword(credentialsId: ARTIFACTORY_CREDENTIALS_ID, usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD')]) {
                                             // TODO: Consider using tooling like artifactory-download-spec to get license.zip. Post-Infrastructure migration answer.
                                             sh "mkdir -p licenses && cd licenses && curl -fs -o zowe_licenses_full.zip $ZOWE_LICENSE_ZIP_URL"
-                                            sh "./scripts/npm_login.sh $USERNAME $PASSWORD \"$ARTIFACTORY_EMAIL\" '--registry=${ZOWE_ARTIFACTORY_URL} --scope=@zowe'"
+                                            sh "../scripts/npm_login.sh $USERNAME $PASSWORD \"$ARTIFACTORY_EMAIL\" '--registry=${ZOWE_ARTIFACTORY_URL} --scope=@zowe'"
                                         }
                                         sh "npm install jsonfile"
 
@@ -529,10 +529,10 @@ pipeline {
                                         sh "npm pack @zowe/zos-workflows-for-zowe-sdk@next"
                                         sh "npm pack @zowe/zosmf-for-zowe-sdk@next"
 
-                                        sh "./scripts/repackage_bundle.sh *.tgz" // Outputs a zowe-cli-package.zip
+                                        sh "../scripts/repackage_bundle.sh *.tgz" // Outputs a zowe-cli-package.zip
                                         sh "mv zowe-cli-package.zip ../zowe-nodejs-sdk-${ZOWE_CLI_BUNDLE_NEXT_VERSION}.zip"
 
-                                        sh "./scripts/generate_typedoc.sh next" // Outputs a zowe-node-sdk-typedoc.zip
+                                        sh "../scripts/generate_typedoc.sh next" // Outputs a zowe-node-sdk-typedoc.zip
                                         sh "mv zowe-node-sdk-typedoc.zip ../zowe-nodejs-sdk-typedoc-${ZOWE_CLI_BUNDLE_NEXT_VERSION}.zip"
 
                                         archiveArtifacts artifacts: "../zowe-nodejs-sdk*-${ZOWE_CLI_BUNDLE_NEXT_VERSION}.zip"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -116,42 +116,41 @@ pipeline {
         stage('Create Bundles') {
             parallel {
                 stage('Create Bundles (LTS)') {
-                    dir("lts") {
-                        stages {
-                            /************************************************************************
-                            * STAGE
-                            * -----
-                            * Build Zowe CLI Bundle
-                            *
-                            * TIMEOUT
-                            * -------
-                            * 10 Minutes
-                            *
-                            * EXECUTION CONDITIONS
-                            * --------------------
-                            * - Always
-                            *
-                            * DESCRIPTION
-                            * ----------
-                            * Gets the latest version of the Zowe CLI and SCS plugin from Zowe
-                            * Artifactory. Creates an archive with 'fat' versions of the CLI and Plugin -
-                            *  dependencies are bundled.
-                            *
-                            * OUTPUTS
-                            * -------
-                            * A Zowe CLI Archive containing Zowe CLI and Zowe CLI Secure Credential Store Plugin
-                            ************************************************************************/
-                            stage('CLI Core (LTS)') {
-                                when {
-                                    allOf {
-                                        expression {
-                                            return BRANCH_NAME.equals(MASTER_BRANCH)
-                                        }
+                    stages {
+                        /************************************************************************
+                        * STAGE
+                        * -----
+                        * Build Zowe CLI Bundle
+                        *
+                        * TIMEOUT
+                        * -------
+                        * 10 Minutes
+                        *
+                        * EXECUTION CONDITIONS
+                        * --------------------
+                        * - Always
+                        *
+                        * DESCRIPTION
+                        * ----------
+                        * Gets the latest version of the Zowe CLI and SCS plugin from Zowe
+                        * Artifactory. Creates an archive with 'fat' versions of the CLI and Plugin -
+                        *  dependencies are bundled.
+                        *
+                        * OUTPUTS
+                        * -------
+                        * A Zowe CLI Archive containing Zowe CLI and Zowe CLI Secure Credential Store Plugin
+                        ************************************************************************/
+                        stage('CLI Core (LTS)') {
+                            when {
+                                allOf {
+                                    expression {
+                                        return BRANCH_NAME.equals(MASTER_BRANCH)
                                     }
                                 }
-                                steps {
+                            }
+                            steps {
+                                dir("lts") {
                                     timeout(time: 10, unit: 'MINUTES') {
-
                                         sh "npm set registry https://registry.npmjs.org/"
                                         sh "npm set @zowe:registry ${ZOWE_ARTIFACTORY_URL}"
                                         withCredentials([usernamePassword(credentialsId: ARTIFACTORY_CREDENTIALS_ID, usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD')]) {
@@ -174,41 +173,42 @@ pipeline {
                                     }
                                 }
                             }
-                            /************************************************************************
-                            * STAGE
-                            * -----
-                            * Build Zowe CLI Plugins Bundle
-                            *
-                            * TIMEOUT
-                            * -------
-                            * 10 Minutes
-                            *
-                            * EXECUTION CONDITIONS
-                            * --------------------
-                            * - Always
-                            *
-                            * DESCRIPTION
-                            * ----------
-                            * Gets the latest version of the Zowe CLI Plugins from Zowe
-                            * Artifactory. Creates an archive with 'fat' versions of the Plugins -
-                            *  dependencies are bundled.
-                            *
-                            * OUTPUTS
-                            * -------
-                            * A Zowe CLI Plugins Archive containing Zowe CLI DB2 Plugin, Zowe CLI CICS Plugin,
-                            * Zowe CLI z/OS FTP Plugin, Zowe CLI IMS Plugin, and Zowe CLI MQ Plugin.
-                            ************************************************************************/
-                            stage('CLI Plugins (LTS)') {
-                                when {
-                                    allOf {
-                                        expression {
-                                            return BRANCH_NAME.equals(MASTER_BRANCH)
-                                        }
+                        }
+                        /************************************************************************
+                        * STAGE
+                        * -----
+                        * Build Zowe CLI Plugins Bundle
+                        *
+                        * TIMEOUT
+                        * -------
+                        * 10 Minutes
+                        *
+                        * EXECUTION CONDITIONS
+                        * --------------------
+                        * - Always
+                        *
+                        * DESCRIPTION
+                        * ----------
+                        * Gets the latest version of the Zowe CLI Plugins from Zowe
+                        * Artifactory. Creates an archive with 'fat' versions of the Plugins -
+                        *  dependencies are bundled.
+                        *
+                        * OUTPUTS
+                        * -------
+                        * A Zowe CLI Plugins Archive containing Zowe CLI DB2 Plugin, Zowe CLI CICS Plugin,
+                        * Zowe CLI z/OS FTP Plugin, Zowe CLI IMS Plugin, and Zowe CLI MQ Plugin.
+                        ************************************************************************/
+                        stage('CLI Plugins (LTS)') {
+                            when {
+                                allOf {
+                                    expression {
+                                        return BRANCH_NAME.equals(MASTER_BRANCH)
                                     }
                                 }
-                                steps {
+                            }
+                            steps {
+                                dir("lts") {
                                     timeout(time: 10, unit: 'MINUTES') {
-
                                         sh "npm set registry https://registry.npmjs.org/"
                                         sh "npm set @zowe:registry ${ZOWE_ARTIFACTORY_URL}"
                                         withCredentials([usernamePassword(credentialsId: ARTIFACTORY_CREDENTIALS_ID, usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD')]) {
@@ -233,40 +233,41 @@ pipeline {
                                     }
                                 }
                             }
-                            /************************************************************************
-                            * STAGE
-                            * -----
-                            * Build Zowe NodeJS SDK Bundle
-                            *
-                            * TIMEOUT
-                            * -------
-                            * 10 Minutes
-                            *
-                            * EXECUTION CONDITIONS
-                            * --------------------
-                            * - Always
-                            *
-                            * DESCRIPTION
-                            * ----------
-                            * Gets the latest version of the Zowe NodeJS SDK package from NPM
-                            * Creates an archive with 'fat' versions of the Plugins -
-                            *   dependencies are bundled.
-                            *
-                            * OUTPUTS
-                            * -------
-                            * A Zowe NodeJS SDK Archive.
-                            ************************************************************************/
-                            stage('NodeJS SDK (LTS)') {
-                                when {
-                                    allOf {
-                                        expression {
-                                            return BRANCH_NAME.equals(MASTER_BRANCH)
-                                        }
+                        }
+                        /************************************************************************
+                        * STAGE
+                        * -----
+                        * Build Zowe NodeJS SDK Bundle
+                        *
+                        * TIMEOUT
+                        * -------
+                        * 10 Minutes
+                        *
+                        * EXECUTION CONDITIONS
+                        * --------------------
+                        * - Always
+                        *
+                        * DESCRIPTION
+                        * ----------
+                        * Gets the latest version of the Zowe NodeJS SDK package from NPM
+                        * Creates an archive with 'fat' versions of the Plugins -
+                        *   dependencies are bundled.
+                        *
+                        * OUTPUTS
+                        * -------
+                        * A Zowe NodeJS SDK Archive.
+                        ************************************************************************/
+                        stage('NodeJS SDK (LTS)') {
+                            when {
+                                allOf {
+                                    expression {
+                                        return BRANCH_NAME.equals(MASTER_BRANCH)
                                     }
                                 }
-                                steps {
+                            }
+                            steps {
+                                dir("lts") {
                                     timeout(time: 10, unit: 'MINUTES') {
-
                                         sh "npm set registry https://registry.npmjs.org/"
                                         sh "npm set @zowe:registry ${ZOWE_ARTIFACTORY_URL}"
                                         withCredentials([usernamePassword(credentialsId: ARTIFACTORY_CREDENTIALS_ID, usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD')]) {
@@ -301,36 +302,38 @@ pipeline {
                                     }
                                 }
                             }
-                            /************************************************************************
-                            * STAGE
-                            * -----
-                            * Build Zowe Python SDK Bundle
-                            *
-                            * TIMEOUT
-                            * -------
-                            * 10 Minutes
-                            *
-                            * EXECUTION CONDITIONS
-                            * --------------------
-                            * - Always
-                            *
-                            * DESCRIPTION
-                            * ----------
-                            * Gets the latest version of the Zowe Python SDK package from pypi.org
-                            *
-                            * OUTPUTS
-                            * -------
-                            * A Zowe Python SDK Archive.
-                            ************************************************************************/
-                            stage('Python SDK (LTS)') {
-                                when {
-                                    allOf {
-                                        expression {
-                                            return BRANCH_NAME.equals(MASTER_BRANCH)
-                                        }
+                        }
+                        /************************************************************************
+                        * STAGE
+                        * -----
+                        * Build Zowe Python SDK Bundle
+                        *
+                        * TIMEOUT
+                        * -------
+                        * 10 Minutes
+                        *
+                        * EXECUTION CONDITIONS
+                        * --------------------
+                        * - Always
+                        *
+                        * DESCRIPTION
+                        * ----------
+                        * Gets the latest version of the Zowe Python SDK package from pypi.org
+                        *
+                        * OUTPUTS
+                        * -------
+                        * A Zowe Python SDK Archive.
+                        ************************************************************************/
+                        stage('Python SDK (LTS)') {
+                            when {
+                                allOf {
+                                    expression {
+                                        return BRANCH_NAME.equals(MASTER_BRANCH)
                                     }
                                 }
-                                steps {
+                            }
+                            steps {
+                                dir("lts") {
                                     timeout(time: 10, unit: 'MINUTES') {
                                         // Download all zowe wheels into a temp folder
                                         sh "mkdir -p temp && cd temp && pip3 download zowe"
@@ -350,42 +353,41 @@ pipeline {
                 }
 
                 stage('Create Bundles (Next)') {
-                    dir("next") {
-                        stages {
-                            /************************************************************************
-                            * STAGE
-                            * -----
-                            * Build Zowe CLI Bundle
-                            *
-                            * TIMEOUT
-                            * -------
-                            * 10 Minutes
-                            *
-                            * EXECUTION CONDITIONS
-                            * --------------------
-                            * - Always
-                            *
-                            * DESCRIPTION
-                            * ----------
-                            * Gets the latest version of the Zowe CLI and SCS plugin from Zowe
-                            * Artifactory. Creates an archive with 'fat' versions of the CLI and Plugin -
-                            *  dependencies are bundled.
-                            *
-                            * OUTPUTS
-                            * -------
-                            * A Zowe CLI Archive containing Zowe CLI and Zowe CLI Secure Credential Store Plugin
-                            ************************************************************************/
-                            stage('CLI Core (Next)') {
-                                when {
-                                    allOf {
-                                        expression {
-                                            return BRANCH_NAME.equals(MASTER_BRANCH)
-                                        }
+                    stages {
+                        /************************************************************************
+                        * STAGE
+                        * -----
+                        * Build Zowe CLI Bundle
+                        *
+                        * TIMEOUT
+                        * -------
+                        * 10 Minutes
+                        *
+                        * EXECUTION CONDITIONS
+                        * --------------------
+                        * - Always
+                        *
+                        * DESCRIPTION
+                        * ----------
+                        * Gets the latest version of the Zowe CLI and SCS plugin from Zowe
+                        * Artifactory. Creates an archive with 'fat' versions of the CLI and Plugin -
+                        *  dependencies are bundled.
+                        *
+                        * OUTPUTS
+                        * -------
+                        * A Zowe CLI Archive containing Zowe CLI and Zowe CLI Secure Credential Store Plugin
+                        ************************************************************************/
+                        stage('CLI Core (Next)') {
+                            when {
+                                allOf {
+                                    expression {
+                                        return BRANCH_NAME.equals(MASTER_BRANCH)
                                     }
                                 }
-                                steps {
+                            }
+                            steps {
+                                dir("next") {
                                     timeout(time: 10, unit: 'MINUTES') {
-
                                         sh "npm set registry https://registry.npmjs.org/"
                                         sh "npm set @zowe:registry ${ZOWE_ARTIFACTORY_URL}"
                                         withCredentials([usernamePassword(credentialsId: ARTIFACTORY_CREDENTIALS_ID, usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD')]) {
@@ -409,41 +411,42 @@ pipeline {
                                     }
                                 }
                             }
-                            /************************************************************************
-                            * STAGE
-                            * -----
-                            * Build Zowe CLI Plugins Bundle
-                            *
-                            * TIMEOUT
-                            * -------
-                            * 10 Minutes
-                            *
-                            * EXECUTION CONDITIONS
-                            * --------------------
-                            * - Always
-                            *
-                            * DESCRIPTION
-                            * ----------
-                            * Gets the latest version of the Zowe CLI Plugins from Zowe
-                            * Artifactory. Creates an archive with 'fat' versions of the Plugins -
-                            *  dependencies are bundled.
-                            *
-                            * OUTPUTS
-                            * -------
-                            * A Zowe CLI Plugins Archive containing Zowe CLI DB2 Plugin, Zowe CLI CICS Plugin,
-                            * Zowe CLI z/OS FTP Plugin, Zowe CLI IMS Plugin, and Zowe CLI MQ Plugin.
-                            ************************************************************************/
-                            stage('CLI Plugins (Next)') {
-                                when {
-                                    allOf {
-                                        expression {
-                                            return BRANCH_NAME.equals(MASTER_BRANCH)
-                                        }
+                        }
+                        /************************************************************************
+                        * STAGE
+                        * -----
+                        * Build Zowe CLI Plugins Bundle
+                        *
+                        * TIMEOUT
+                        * -------
+                        * 10 Minutes
+                        *
+                        * EXECUTION CONDITIONS
+                        * --------------------
+                        * - Always
+                        *
+                        * DESCRIPTION
+                        * ----------
+                        * Gets the latest version of the Zowe CLI Plugins from Zowe
+                        * Artifactory. Creates an archive with 'fat' versions of the Plugins -
+                        *  dependencies are bundled.
+                        *
+                        * OUTPUTS
+                        * -------
+                        * A Zowe CLI Plugins Archive containing Zowe CLI DB2 Plugin, Zowe CLI CICS Plugin,
+                        * Zowe CLI z/OS FTP Plugin, Zowe CLI IMS Plugin, and Zowe CLI MQ Plugin.
+                        ************************************************************************/
+                        stage('CLI Plugins (Next)') {
+                            when {
+                                allOf {
+                                    expression {
+                                        return BRANCH_NAME.equals(MASTER_BRANCH)
                                     }
                                 }
-                                steps {
+                            }
+                            steps {
+                                dir("next") {
                                     timeout(time: 10, unit: 'MINUTES') {
-
                                         sh "npm set registry https://registry.npmjs.org/"
                                         sh "npm set @zowe:registry ${ZOWE_ARTIFACTORY_URL}"
                                         withCredentials([usernamePassword(credentialsId: ARTIFACTORY_CREDENTIALS_ID, usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD')]) {
@@ -470,40 +473,41 @@ pipeline {
                                     }
                                 }
                             }
-                            /************************************************************************
-                            * STAGE
-                            * -----
-                            * Build Zowe NodeJS SDK Bundle
-                            *
-                            * TIMEOUT
-                            * -------
-                            * 10 Minutes
-                            *
-                            * EXECUTION CONDITIONS
-                            * --------------------
-                            * - Always
-                            *
-                            * DESCRIPTION
-                            * ----------
-                            * Gets the latest version of the Zowe NodeJS SDK package from NPM
-                            * Creates an archive with 'fat' versions of the Plugins -
-                            *   dependencies are bundled.
-                            *
-                            * OUTPUTS
-                            * -------
-                            * A Zowe NodeJS SDK Archive.
-                            ************************************************************************/
-                            stage('NodeJS SDK (Next)') {
-                                when {
-                                    allOf {
-                                        expression {
-                                            return BRANCH_NAME.equals(MASTER_BRANCH)
-                                        }
+                        }
+                        /************************************************************************
+                        * STAGE
+                        * -----
+                        * Build Zowe NodeJS SDK Bundle
+                        *
+                        * TIMEOUT
+                        * -------
+                        * 10 Minutes
+                        *
+                        * EXECUTION CONDITIONS
+                        * --------------------
+                        * - Always
+                        *
+                        * DESCRIPTION
+                        * ----------
+                        * Gets the latest version of the Zowe NodeJS SDK package from NPM
+                        * Creates an archive with 'fat' versions of the Plugins -
+                        *   dependencies are bundled.
+                        *
+                        * OUTPUTS
+                        * -------
+                        * A Zowe NodeJS SDK Archive.
+                        ************************************************************************/
+                        stage('NodeJS SDK (Next)') {
+                            when {
+                                allOf {
+                                    expression {
+                                        return BRANCH_NAME.equals(MASTER_BRANCH)
                                     }
                                 }
-                                steps {
+                            }
+                            steps {
+                                dir("next") {
                                     timeout(time: 10, unit: 'MINUTES') {
-
                                         sh "npm set registry https://registry.npmjs.org/"
                                         sh "npm set @zowe:registry ${ZOWE_ARTIFACTORY_URL}"
                                         withCredentials([usernamePassword(credentialsId: ARTIFACTORY_CREDENTIALS_ID, usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD')]) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -534,10 +534,10 @@ pipeline {
                         def targetVersion = ZOWE_CLI_BUNDLE_VERSION
                         def targetRepository = targetVersion.contains("-SNAPSHOT") ? ARTIFACTORY_SNAPSHOT_REPO : ARTIFACTORY_RELEASE_REPO
 
-                        // Upload Core CLI and SCS (zowe-cli-package)
+                        // LTS: Upload Core CLI and SCS (zowe-cli-package)
                         def uploadSpec = """{
                         "files": [{
-                            "pattern": "zowe-cli-package-*.zip",
+                            "pattern": "zowe-cli-package-(!next)*.zip",
                             "target": "${targetRepository}/org/zowe/cli/zowe-cli-package/${targetVersion}/"
                         }]
                         }"""
@@ -545,10 +545,10 @@ pipeline {
                         server.upload spec: uploadSpec, buildInfo: buildInfo
                         server.publishBuildInfo buildInfo
 
-                        // Upload all other plugins (zowe-cli-plugins)
+                        // LTS: Upload all other plugins (zowe-cli-plugins)
                         uploadSpec = """{
                         "files": [{
-                            "pattern": "zowe-cli-plugins-*.zip",
+                            "pattern": "zowe-cli-plugins-(!next)*.zip",
                             "target": "${targetRepository}/org/zowe/cli/zowe-cli-plugins/${targetVersion}/"
                         }]
                         }"""
@@ -556,10 +556,10 @@ pipeline {
                         server.upload spec: uploadSpec, buildInfo: buildInfo
                         server.publishBuildInfo buildInfo
 
-                        // Upload NodeJS SDK packages (zowe-nodejs-sdk)
+                        // LTS: Upload NodeJS SDK packages (zowe-nodejs-sdk)
                         uploadSpec = """{
                         "files": [{
-                            "pattern": "zowe-nodejs-sdk-*.zip",
+                            "pattern": "zowe-nodejs-sdk-(!next)*.zip",
                             "target": "${targetRepository}/org/zowe/sdk/zowe-nodejs-sdk/${targetVersion}/"
                         }]
                         }"""
@@ -567,11 +567,44 @@ pipeline {
                         server.upload spec: uploadSpec, buildInfo: buildInfo
                         server.publishBuildInfo buildInfo
 
-                        // Upload Python SDK packages (zowe-python-sdk)
+                        // LTS: Upload Python SDK packages (zowe-python-sdk)
                         uploadSpec = """{
                         "files": [{
-                            "pattern": "zowe-python-sdk-*.zip",
+                            "pattern": "zowe-python-sdk-(!next)*.zip",
                             "target": "${targetRepository}/org/zowe/sdk/zowe-python-sdk/${targetVersion}/"
+                        }]
+                        }"""
+                        buildInfo = Artifactory.newBuildInfo()
+                        server.upload spec: uploadSpec, buildInfo: buildInfo
+                        server.publishBuildInfo buildInfo
+
+                        // Next: Upload Core CLI and SCS (zowe-cli-package)
+                        def uploadSpec = """{
+                        "files": [{
+                            "pattern": "zowe-cli-package-next-*.zip",
+                            "target": "${targetRepository}/org/zowe/cli/zowe-cli-package/next/${targetVersion}/"
+                        }]
+                        }"""
+                        def buildInfo = Artifactory.newBuildInfo()
+                        server.upload spec: uploadSpec, buildInfo: buildInfo
+                        server.publishBuildInfo buildInfo
+
+                        // Next: Upload all other plugins (zowe-cli-plugins)
+                        uploadSpec = """{
+                        "files": [{
+                            "pattern": "zowe-cli-plugins-next-*.zip",
+                            "target": "${targetRepository}/org/zowe/cli/zowe-cli-plugins/next/${targetVersion}/"
+                        }]
+                        }"""
+                        buildInfo = Artifactory.newBuildInfo()
+                        server.upload spec: uploadSpec, buildInfo: buildInfo
+                        server.publishBuildInfo buildInfo
+
+                        // Next: Upload NodeJS SDK packages (zowe-nodejs-sdk)
+                        uploadSpec = """{
+                        "files": [{
+                            "pattern": "zowe-nodejs-sdk-next-*.zip",
+                            "target": "${targetRepository}/org/zowe/sdk/zowe-nodejs-sdk/next/${targetVersion}/"
                         }]
                         }"""
                         buildInfo = Artifactory.newBuildInfo()

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -174,7 +174,7 @@ pipeline {
                                         sh "../scripts/repackage_bundle.sh *.tgz"
                                         sh "mv zowe-cli-package.zip ../zowe-cli-package-${ZOWE_CLI_BUNDLE_VERSION}.zip"
 
-                                        archiveArtifacts artifacts: "zowe-cli-package-${ZOWE_CLI_BUNDLE_VERSION}.zip"
+                                        archiveArtifacts artifacts: "**/zowe-cli-package-${ZOWE_CLI_BUNDLE_VERSION}.zip"
 
                                         // Remove all tgzs after bundle is archived
                                         sh "rm -f *.tgz"
@@ -220,7 +220,7 @@ pipeline {
                                         sh "../scripts/repackage_bundle.sh *.tgz"
                                         sh "mv zowe-cli-package.zip ../zowe-cli-plugins-${ZOWE_CLI_BUNDLE_VERSION}.zip"
 
-                                        archiveArtifacts artifacts: "zowe-cli-plugins-${ZOWE_CLI_BUNDLE_VERSION}.zip"
+                                        archiveArtifacts artifacts: "**/zowe-cli-plugins-${ZOWE_CLI_BUNDLE_VERSION}.zip"
 
                                         // Remove all tgzs after bundle is archived
                                         sh "rm -f *.tgz"
@@ -275,7 +275,7 @@ pipeline {
                                         sh "../scripts/generate_typedoc.sh ${ZOWE_CLI_BUNDLE_VERSION} ${imperativeVersion} ${zoweCliVersion}" // Outputs a zowe-node-sdk-typedoc.zip
                                         sh "mv zowe-node-sdk-typedoc.zip ../zowe-nodejs-sdk-typedoc-${ZOWE_CLI_BUNDLE_VERSION}.zip"
 
-                                        archiveArtifacts artifacts: "zowe-nodejs-sdk*-${ZOWE_CLI_BUNDLE_VERSION}.zip"
+                                        archiveArtifacts artifacts: "**/zowe-nodejs-sdk*-${ZOWE_CLI_BUNDLE_VERSION}.zip"
 
                                         // Remove all tgzs after bundle is archived
                                         sh "rm -f *.tgz"
@@ -317,7 +317,7 @@ pipeline {
 
                                         // Archive the zowe Python SDK
                                         sh "mv zowe-sdk.zip ../zowe-python-sdk-${ZOWE_CLI_BUNDLE_VERSION}.zip"
-                                        archiveArtifacts artifacts: "zowe-python-sdk-${ZOWE_CLI_BUNDLE_VERSION}.zip"
+                                        archiveArtifacts artifacts: "**/zowe-python-sdk-${ZOWE_CLI_BUNDLE_VERSION}.zip"
                                     }
                                 }
                             }
@@ -363,7 +363,7 @@ pipeline {
                                         sh "../scripts/repackage_bundle.sh *.tgz"
                                         sh "mv zowe-cli-package.zip ../zowe-cli-package-${ZOWE_CLI_BUNDLE_NEXT_VERSION}.zip"
 
-                                        archiveArtifacts artifacts: "zowe-cli-package-${ZOWE_CLI_BUNDLE_NEXT_VERSION}.zip"
+                                        archiveArtifacts artifacts: "**/zowe-cli-package-${ZOWE_CLI_BUNDLE_NEXT_VERSION}.zip"
 
                                         // Remove all tgzs after bundle is archived
                                         sh "rm -f *.tgz"
@@ -411,7 +411,7 @@ pipeline {
                                         sh "../scripts/repackage_bundle.sh *.tgz"
                                         sh "mv zowe-cli-package.zip ../zowe-cli-plugins-${ZOWE_CLI_BUNDLE_NEXT_VERSION}.zip"
 
-                                        archiveArtifacts artifacts: "zowe-cli-plugins-${ZOWE_CLI_BUNDLE_NEXT_VERSION}.zip"
+                                        archiveArtifacts artifacts: "**/zowe-cli-plugins-${ZOWE_CLI_BUNDLE_NEXT_VERSION}.zip"
 
                                         // Remove all tgzs after bundle is archived
                                         sh "rm -f *.tgz"
@@ -466,7 +466,7 @@ pipeline {
                                         sh "../scripts/generate_typedoc.sh next" // Outputs a zowe-node-sdk-typedoc.zip
                                         sh "mv zowe-node-sdk-typedoc.zip ../zowe-nodejs-sdk-typedoc-${ZOWE_CLI_BUNDLE_NEXT_VERSION}.zip"
 
-                                        archiveArtifacts artifacts: "zowe-nodejs-sdk*-${ZOWE_CLI_BUNDLE_NEXT_VERSION}.zip"
+                                        archiveArtifacts artifacts: "**/zowe-nodejs-sdk*-${ZOWE_CLI_BUNDLE_NEXT_VERSION}.zip"
 
                                         // Remove all tgzs after bundle is archived
                                         sh "rm -f *.tgz"

--- a/scripts/configure-to-bundle.js
+++ b/scripts/configure-to-bundle.js
@@ -19,7 +19,7 @@ const jsonfile = require("jsonfile");
 const path = require("path");
 
 // Assumes this is being run from the 'lts' or 'next' build dir; the calling script extracts package to ./temp/
-const packageLocation = path.join(process.cwd() + "/temp/package", "package.json");
+const packageLocation = path.join(process.cwd(), "temp", "package", "package.json");
 
 const packageJson = jsonfile.readFileSync(packageLocation);
 

--- a/scripts/configure-to-bundle.js
+++ b/scripts/configure-to-bundle.js
@@ -18,8 +18,8 @@
 const jsonfile = require("jsonfile");
 const path = require("path");
 
-// Assumes this is being run from the 'scripts' build dir; the calling script extracts package to <root>/temp/
-const packageLocation = path.join(__dirname + "/../temp/package", "package.json");
+// Assumes this is being run from the 'lts' or 'next' build dir; the calling script extracts package to ./temp/
+const packageLocation = path.join(process.cwd() + "/temp/package", "package.json");
 
 const packageJson = jsonfile.readFileSync(packageLocation);
 

--- a/scripts/configure-to-bundle.js
+++ b/scripts/configure-to-bundle.js
@@ -34,6 +34,9 @@ packageJson.bundledDependencies = [];
 for(const x in packageJson.dependencies) {
     packageJson.bundledDependencies.push(x);
 }
+for(const x in (packageJson.optionalDependencies || {})) {
+    packageJson.bundledDependencies.push(x);
+}
 
 console.log("====NEW PACKAGE.JSON====");
 console.log(packageJson);

--- a/scripts/generate_typedoc.sh
+++ b/scripts/generate_typedoc.sh
@@ -10,16 +10,22 @@
 #
 ###
 
-zoweVersion=$1
-imperativeVersion=$2
-cliVersion=$3
+if [ $1 != "next" ]; then
+  zoweVersion=v$1
+  imperativeVersion=v$2
+  cliVersion=v$3
+else
+  zoweVersion=vNext
+  imperativeVersion=next
+  cliVersion=next
+fi
 
 mkdir -p node-sdk
 cd node-sdk
 
 # Clone Imperative and Zowe CLI repos to get the TypeScript source
-git clone -b v${imperativeVersion} --depth 1 https://github.com/zowe/imperative.git
-git clone -b v${cliVersion} --depth 1 https://github.com/zowe/zowe-cli.git
+git clone -b ${imperativeVersion} --depth 1 https://github.com/zowe/imperative.git
+git clone -b ${cliVersion} --depth 1 https://github.com/zowe/zowe-cli.git
 
 # Install typedoc along with dependencies and plugins
 npm init -y
@@ -27,8 +33,8 @@ npm install -D --legacy-peer-deps @types/node typescript@^3.8.0 typedoc@^0.19.0 
   @strictsoftware/typedoc-plugin-monorepo typedoc-plugin-sourcefile-url
 
 # Transform relative URLs to absolute URLs in Imperative and CLI readmes
-sed -i "s [(]\(CONTRIBUTING\|LICENSE\) (https://github.com/zowe/imperative/blob/v$imperativeVersion/\1 " imperative/README.md
-sed -i "s \./ https://github.com/zowe/zowe-cli/blob/v$cliVersion/ " zowe-cli/README.md
+sed -i "s [(]\(CONTRIBUTING\|LICENSE\) (https://github.com/zowe/imperative/blob/$imperativeVersion/\1 " imperative/README.md
+sed -i "s \./ https://github.com/zowe/zowe-cli/blob/$cliVersion/ " zowe-cli/README.md
 
 # Create directory structure for Imperative and SDK packages
 mkdir -p node_modules/@zowe/imperative
@@ -48,43 +54,43 @@ cat > sourcefile-map.json << EOF
 [
   {
     "pattern": "^@zowe/imperative",
-    "replace": "https://github.com/zowe/imperative/blob/v$imperativeVersion"
+    "replace": "https://github.com/zowe/imperative/blob/$imperativeVersion"
   },
   {
     "pattern": "^@zowe/core-for-zowe-sdk",
-    "replace": "https://github.com/zowe/zowe-cli/blob/v${cliVersion}/packages/core"
+    "replace": "https://github.com/zowe/zowe-cli/blob/${cliVersion}/packages/core"
   },
   {
     "pattern": "^@zowe/provisioning-for-zowe-sdk",
-    "replace": "https://github.com/zowe/zowe-cli/blob/v${cliVersion}/packages/provisioning"
+    "replace": "https://github.com/zowe/zowe-cli/blob/${cliVersion}/packages/provisioning"
   },
   {
     "pattern": "^@zowe/zos-console-for-zowe-sdk",
-    "replace": "https://github.com/zowe/zowe-cli/blob/v${cliVersion}/packages/zosconsole"
+    "replace": "https://github.com/zowe/zowe-cli/blob/${cliVersion}/packages/zosconsole"
   },
   {
     "pattern": "^@zowe/zos-files-for-zowe-sdk",
-    "replace": "https://github.com/zowe/zowe-cli/blob/v${cliVersion}/packages/zosfiles"
+    "replace": "https://github.com/zowe/zowe-cli/blob/${cliVersion}/packages/zosfiles"
   },
   {
     "pattern": "^@zowe/zos-jobs-for-zowe-sdk",
-    "replace": "https://github.com/zowe/zowe-cli/blob/v${cliVersion}/packages/zosjobs"
+    "replace": "https://github.com/zowe/zowe-cli/blob/${cliVersion}/packages/zosjobs"
   },
   {
     "pattern": "^@zowe/zos-tso-for-zowe-sdk",
-    "replace": "https://github.com/zowe/zowe-cli/blob/v${cliVersion}/packages/zostso"
+    "replace": "https://github.com/zowe/zowe-cli/blob/${cliVersion}/packages/zostso"
   },
   {
     "pattern": "^@zowe/zos-uss-for-zowe-sdk",
-    "replace": "https://github.com/zowe/zowe-cli/blob/v${cliVersion}/packages/zosuss"
+    "replace": "https://github.com/zowe/zowe-cli/blob/${cliVersion}/packages/zosuss"
   },
   {
     "pattern": "^@zowe/zos-workflows-for-zowe-sdk",
-    "replace": "https://github.com/zowe/zowe-cli/blob/v${cliVersion}/packages/workflows"
+    "replace": "https://github.com/zowe/zowe-cli/blob/${cliVersion}/packages/workflows"
   },
   {
     "pattern": "^@zowe/zosmf-for-zowe-sdk",
-    "replace": "https://github.com/zowe/zowe-cli/blob/v${cliVersion}/packages/zosmf"
+    "replace": "https://github.com/zowe/zowe-cli/blob/${cliVersion}/packages/zosmf"
   }
 ]
 EOF
@@ -100,7 +106,7 @@ cat > typedoc.json << EOF
   ],
   "excludeNotExported": true,
   "ignoreCompilerErrors": true,
-  "name": "Zowe Node.js SDK - v$zoweVersion",
+  "name": "Zowe Node.js SDK - $zoweVersion",
   "out": "typedoc",
   "readme": "zowe-cli/README.md",
   "external-modulemap": ".*(@zowe\/[^\/]+)\/.*",

--- a/scripts/repackage_bundle.sh
+++ b/scripts/repackage_bundle.sh
@@ -23,7 +23,7 @@ do
 
 
     cd temp/package
-    cp ../../.npmrc .
+    cp ../../../.npmrc .
     npm install
 
     # Extra work required for the db2 plugin with respect to packing the ibm_db plugin

--- a/scripts/repackage_bundle.sh
+++ b/scripts/repackage_bundle.sh
@@ -19,7 +19,7 @@ do
     tar xzf $tar -C temp
 
     # Changes the package.json format
-    node "$(dirname \"$0\")/configure-to-bundle.js"
+    node "$(dirname $0)/configure-to-bundle.js"
 
 
     cd temp/package

--- a/scripts/repackage_bundle.sh
+++ b/scripts/repackage_bundle.sh
@@ -10,6 +10,7 @@
 #
 ###
 
+set -ex
 mkdir -p packed
 
 # Loop through each tar (representing an `npm pack`), and create new tars with packed dependencies.
@@ -21,9 +22,8 @@ do
     # Changes the package.json format
     node "$(dirname $0)/configure-to-bundle.js"
 
-
     cd temp/package
-    cp ../../../.npmrc .
+    cp ../../.npmrc . || true
     npm install
 
     # Extra work required for the db2 plugin with respect to packing the ibm_db plugin

--- a/scripts/repackage_bundle.sh
+++ b/scripts/repackage_bundle.sh
@@ -19,7 +19,7 @@ do
     tar xzf $tar -C temp
 
     # Changes the package.json format
-    node "./scripts/configure-to-bundle.js"
+    node "$(dirname \"$0\")/configure-to-bundle.js"
 
 
     cd temp/package

--- a/scripts/repackage_bundle.sh
+++ b/scripts/repackage_bundle.sh
@@ -10,7 +10,6 @@
 #
 ###
 
-set -ex
 mkdir -p packed
 
 # Loop through each tar (representing an `npm pack`), and create new tars with packed dependencies.
@@ -23,7 +22,7 @@ do
     node "$(dirname $0)/configure-to-bundle.js"
 
     cd temp/package
-    cp ../../.npmrc . || true
+    cp ../../.npmrc .
     npm install
 
     # Extra work required for the db2 plugin with respect to packing the ibm_db plugin
@@ -44,7 +43,7 @@ do
     # We include prebuilt native code bundles for Keytar and clean up unwanted binaries.
     if [[ $tar = *"secure-credential-store"* || $tar = "zowe-cli-7"* ]]; then
         mkdir -p "./node_modules/keytar/prebuilds"
-        keytar_ver=`node -e "package = require('./package.json');console.log(package.dependencies['keytar'])"`
+        keytar_ver=`node -e "package = require('./package.json');console.log(package.dependencies['keytar'] || package.optionalDependencies['keytar'])"`
         curl -fOJ https://zowe.jfrog.io/artifactory/libs-snapshot-local/org/zowe/cli/zowe-cli-prebuilds/keytar-${keytar_ver}-prebuilds.tgz
         tar -xzf keytar-*-prebuilds.tgz --directory "./node_modules/keytar/prebuilds"
         rm -r keytar-*-prebuilds.tgz

--- a/scripts/repackage_bundle.sh
+++ b/scripts/repackage_bundle.sh
@@ -39,7 +39,7 @@ do
         rm -rf "./node_modules/ibm_db/installer/clidriver"
     fi
 
-    # Extra work required for the SCS plugin to support offline install.
+    # Extra work required for the SCS plugin (LTS) or CLI (Next) to support offline install.
     # We include prebuilt native code bundles for Keytar and clean up unwanted binaries.
     if [[ $tar = *"secure-credential-store"* || $tar = "zowe-cli-7"* ]]; then
         mkdir -p "./node_modules/keytar/prebuilds"

--- a/scripts/repackage_bundle.sh
+++ b/scripts/repackage_bundle.sh
@@ -42,7 +42,7 @@ do
 
     # Extra work required for the SCS plugin to support offline install.
     # We include prebuilt native code bundles for Keytar and clean up unwanted binaries.
-    if [[ $tar = *"secure-credential-store"* ]]; then
+    if [[ $tar = *"secure-credential-store"* || $tar = "zowe-cli-7"* ]]; then
         mkdir -p "./node_modules/keytar/prebuilds"
         keytar_ver=`node -e "package = require('./package.json');console.log(package.dependencies['keytar'])"`
         curl -fOJ https://zowe.jfrog.io/artifactory/libs-snapshot-local/org/zowe/cli/zowe-cli-prebuilds/keytar-${keytar_ver}-prebuilds.tgz


### PR DESCRIPTION
⚠️ Before merging, change MASTER_BRANCH back to "master" and set DRY_RUN to false

This PR builds a "next" bundle for the CLI Core, CLI plugins, and Node.js SDK. An example of the artifacts it produces can be seen here: https://wash.zowe.org:8443/blue/organizations/jenkins/Zowe%20CLI%20Bundle/detail/PR-32/4/artifacts/

The separate "next" branch in this repository is no longer necessary and can be deleted, since:
* The main branch now publishes artifacts for both LTS and next
* We can no longer publish typedoc on Wash Jenkins using the next branch

The plan for the "next" bundles is to publish them to zowe.org: https://github.com/zowe/zowe.github.io/pull/167