### PR TITLE
Add zowex binary to CLI core vNext bundle

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -382,10 +382,12 @@ pipeline {
                                         // sh "npm pack @zowe/secure-credential-store-for-zowe-cli@4.1.5"
 
                                         // Download zowex TGZs into packed folder since they don't need repackaging
-                                        script { def zoweDaemonVersion = "0.2.1" }
-                                        dir("packed") {
-                                            for (platform in ["linux", "macos", "windows"]) {
-                                                sh "curl -fLOJ https://github.com/zowe/zowe-cli/releases/download/native-v${zoweDaemonVersion}/zowex-${platform}.tgz"
+                                        script {
+                                            def zoweDaemonVersion = "0.2.1"
+                                            dir("packed") {
+                                                for (platform in ["linux", "macos", "windows"]) {
+                                                    sh "curl -fLOJ https://github.com/zowe/zowe-cli/releases/download/native-v${zoweDaemonVersion}/zowex-${platform}.tgz"
+                                                }
                                             }
                                         }
 


### PR DESCRIPTION
Resolves #37 

Example: https://wash.zowe.org:8443/job/Zowe%20CLI%20Bundle/job/PR-38/1/artifact/zowe-cli-package-next-20210825-SNAPSHOT.zip
![image](https://user-images.githubusercontent.com/22344007/130817026-20e1a1fe-20a0-4f07-869e-4cb1a064cc3c.png)

TODO
* [ ] Document the process for installing zowex from the vNext bundle