### PR TITLE
Fix the NPM registry used to fetch dependencies

### DIFF
--- a/.github/workflows/zowe-cli-bundle.yaml
+++ b/.github/workflows/zowe-cli-bundle.yaml
@@ -58,122 +58,121 @@ jobs:
       run: |
         mkdir -p temp && cd temp
         mkdir -p licenses && cd licenses && cp /tmp/zowe_licenses_full.zip zowe_licenses_full.zip && cd ..
-        echo Alpha && npm view @zowe/cli
         npm pack @zowe/cli@${{ env.NPM_PACKAGE_TAG || steps.versions.outputs.zowe-cli }}
         npm pack @zowe/secure-credential-store-for-zowe-cli@${{ env.NPM_PACKAGE_TAG || steps.versions.outputs.zowe-secure-credential-store-plugin }}
         bash ../scripts/repackage_bundle.sh *.tgz
         mv zowe-cli-package.zip ../zowe-cli-package-${{ env.ZOWE_CLI_BUNDLE_VERSION }}.zip
         rm -rf *
     
-    # - name: Create CLI Plugins LTS Bundle
-    #   run: |
-    #     mkdir -p temp && cd temp
-    #     mkdir -p licenses && cd licenses && cp /tmp/zowe_licenses_full.zip zowe_licenses_full.zip && cd ..
-    #     npm pack @zowe/cics-for-zowe-cli@${{ env.NPM_PACKAGE_TAG || steps.versions.outputs.zowe-cics-plugin }}
-    #     npm pack @zowe/db2-for-zowe-cli@${{ env.NPM_PACKAGE_TAG || steps.versions.outputs.zowe-db2-plugin }}
-    #     npm pack @zowe/ims-for-zowe-cli@${{ env.NPM_PACKAGE_TAG || steps.versions.outputs.zowe-ims-plugin }}
-    #     npm pack @zowe/mq-for-zowe-cli@${{ env.NPM_PACKAGE_TAG || steps.versions.outputs.zowe-mq-plugin }}
-    #     npm pack @zowe/zos-ftp-for-zowe-cli@${{ env.NPM_PACKAGE_TAG || steps.versions.outputs.zowe-zos-ftp-plugin }}
-    #     bash ../scripts/repackage_bundle.sh *.tgz
-    #     mv zowe-cli-package.zip ../zowe-cli-plugins-${{ env.ZOWE_CLI_BUNDLE_VERSION }}.zip
-    #     rm -rf *
+    - name: Create CLI Plugins LTS Bundle
+      run: |
+        mkdir -p temp && cd temp
+        mkdir -p licenses && cd licenses && cp /tmp/zowe_licenses_full.zip zowe_licenses_full.zip && cd ..
+        npm pack @zowe/cics-for-zowe-cli@${{ env.NPM_PACKAGE_TAG || steps.versions.outputs.zowe-cics-plugin }}
+        npm pack @zowe/db2-for-zowe-cli@${{ env.NPM_PACKAGE_TAG || steps.versions.outputs.zowe-db2-plugin }}
+        npm pack @zowe/ims-for-zowe-cli@${{ env.NPM_PACKAGE_TAG || steps.versions.outputs.zowe-ims-plugin }}
+        npm pack @zowe/mq-for-zowe-cli@${{ env.NPM_PACKAGE_TAG || steps.versions.outputs.zowe-mq-plugin }}
+        npm pack @zowe/zos-ftp-for-zowe-cli@${{ env.NPM_PACKAGE_TAG || steps.versions.outputs.zowe-zos-ftp-plugin }}
+        bash ../scripts/repackage_bundle.sh *.tgz
+        mv zowe-cli-package.zip ../zowe-cli-plugins-${{ env.ZOWE_CLI_BUNDLE_VERSION }}.zip
+        rm -rf *
     
-    # - name: Create Node.js SDK LTS Bundle
-    #   run: |
-    #     mkdir -p temp && cd temp
-    #     mkdir -p licenses && cd licenses && cp /tmp/zowe_licenses_full.zip zowe_licenses_full.zip && cd ..
-    #     npm pack @zowe/imperative@${{ env.NPM_PACKAGE_TAG || steps.versions.outputs.zowe-imperative }}
-    #     npm pack @zowe/core-for-zowe-sdk@${{ env.NPM_PACKAGE_TAG || steps.versions.outputs.zowe-core-sdk }}
-    #     npm pack @zowe/provisioning-for-zowe-sdk@${{ env.NPM_PACKAGE_TAG || steps.versions.outputs.zowe-provisioning-sdk }}
-    #     npm pack @zowe/zos-console-for-zowe-sdk@${{ env.NPM_PACKAGE_TAG || steps.versions.outputs.zowe-zos-console-sdk }}
-    #     npm pack @zowe/zos-files-for-zowe-sdk@${{ env.NPM_PACKAGE_TAG || steps.versions.outputs.zowe-zos-files-sdk }}
-    #     npm pack @zowe/zos-jobs-for-zowe-sdk@${{ env.NPM_PACKAGE_TAG || steps.versions.outputs.zowe-zos-jobs-sdk }}
-    #     npm pack @zowe/zos-tso-for-zowe-sdk@${{ env.NPM_PACKAGE_TAG || steps.versions.outputs.zowe-zos-tso-sdk }}
-    #     npm pack @zowe/zos-uss-for-zowe-sdk@${{ env.NPM_PACKAGE_TAG || steps.versions.outputs.zowe-zos-uss-sdk }}
-    #     npm pack @zowe/zos-workflows-for-zowe-sdk@${{ env.NPM_PACKAGE_TAG || steps.versions.outputs.zowe-zos-workflows-sdk }}
-    #     npm pack @zowe/zosmf-for-zowe-sdk@${{ env.NPM_PACKAGE_TAG || steps.versions.outputs.zowe-zosmf-sdk }}
-    #     bash ../scripts/repackage_bundle.sh *.tgz
-    #     mv zowe-cli-package.zip ../zowe-nodejs-sdk-${{ env.ZOWE_CLI_BUNDLE_VERSION }}.zip
-    #     bash ../scripts/generate_typedoc.sh ${{ env.ZOWE_CLI_BUNDLE_VERSION }} \
-    #       ${{ steps.versions.outputs.zowe-imperative }} ${{ steps.versions.outputs.zowe-cli }}
-    #     mv zowe-node-sdk-typedoc.zip ../zowe-nodejs-sdk-typedoc-${{ env.ZOWE_CLI_BUNDLE_VERSION }}.zip
-    #     rm -rf *
+    - name: Create Node.js SDK LTS Bundle
+      run: |
+        mkdir -p temp && cd temp
+        mkdir -p licenses && cd licenses && cp /tmp/zowe_licenses_full.zip zowe_licenses_full.zip && cd ..
+        npm pack @zowe/imperative@${{ env.NPM_PACKAGE_TAG || steps.versions.outputs.zowe-imperative }}
+        npm pack @zowe/core-for-zowe-sdk@${{ env.NPM_PACKAGE_TAG || steps.versions.outputs.zowe-core-sdk }}
+        npm pack @zowe/provisioning-for-zowe-sdk@${{ env.NPM_PACKAGE_TAG || steps.versions.outputs.zowe-provisioning-sdk }}
+        npm pack @zowe/zos-console-for-zowe-sdk@${{ env.NPM_PACKAGE_TAG || steps.versions.outputs.zowe-zos-console-sdk }}
+        npm pack @zowe/zos-files-for-zowe-sdk@${{ env.NPM_PACKAGE_TAG || steps.versions.outputs.zowe-zos-files-sdk }}
+        npm pack @zowe/zos-jobs-for-zowe-sdk@${{ env.NPM_PACKAGE_TAG || steps.versions.outputs.zowe-zos-jobs-sdk }}
+        npm pack @zowe/zos-tso-for-zowe-sdk@${{ env.NPM_PACKAGE_TAG || steps.versions.outputs.zowe-zos-tso-sdk }}
+        npm pack @zowe/zos-uss-for-zowe-sdk@${{ env.NPM_PACKAGE_TAG || steps.versions.outputs.zowe-zos-uss-sdk }}
+        npm pack @zowe/zos-workflows-for-zowe-sdk@${{ env.NPM_PACKAGE_TAG || steps.versions.outputs.zowe-zos-workflows-sdk }}
+        npm pack @zowe/zosmf-for-zowe-sdk@${{ env.NPM_PACKAGE_TAG || steps.versions.outputs.zowe-zosmf-sdk }}
+        bash ../scripts/repackage_bundle.sh *.tgz
+        mv zowe-cli-package.zip ../zowe-nodejs-sdk-${{ env.ZOWE_CLI_BUNDLE_VERSION }}.zip
+        bash ../scripts/generate_typedoc.sh ${{ env.ZOWE_CLI_BUNDLE_VERSION }} \
+          ${{ steps.versions.outputs.zowe-imperative }} ${{ steps.versions.outputs.zowe-cli }}
+        mv zowe-node-sdk-typedoc.zip ../zowe-nodejs-sdk-typedoc-${{ env.ZOWE_CLI_BUNDLE_VERSION }}.zip
+        rm -rf *
     
-    # - name: Create Python SDK LTS Bundle
-    #   run: |
-    #     mkdir -p temp && cd temp
-    #     mkdir -p licenses && cd licenses && cp /tmp/zowe_licenses_full.zip zowe_licenses_full.zip && cd ..
-    #     pip3 download zowe
-    #     zip -r zowe-sdk.zip *
-    #     mv zowe-sdk.zip ../zowe-python-sdk-${{ env.ZOWE_CLI_BUNDLE_VERSION }}.zip
-    #     rm -rf *
+    - name: Create Python SDK LTS Bundle
+      run: |
+        mkdir -p temp && cd temp
+        mkdir -p licenses && cd licenses && cp /tmp/zowe_licenses_full.zip zowe_licenses_full.zip && cd ..
+        pip3 download zowe
+        zip -r zowe-sdk.zip *
+        mv zowe-sdk.zip ../zowe-python-sdk-${{ env.ZOWE_CLI_BUNDLE_VERSION }}.zip
+        rm -rf *
 
-    # - name: Create CLI Core Next Bundle
-    #   run: |
-    #     mkdir -p temp && cd temp
-    #     mkdir -p licenses && cd licenses && cp /tmp/zowe_licenses_full.zip zowe_licenses_full.zip && cd ..
-    #     npm pack @zowe/cli@next
-    #     mkdir -p packed && cd packed
-    #     for platform in linux macos windows; do
-    #       curl -fLOJ https://github.com/zowe/zowe-cli/releases/download/native-v${{ steps.versions.outputs.zowe-daemon }}/zowex-$platform.tgz
-    #     done && cd ..
-    #     bash ../scripts/repackage_bundle.sh *.tgz
-    #     mv zowe-cli-package.zip ../zowe-cli-package-${{ env.ZOWE_CLI_BUNDLE_NEXT_VERSION }}.zip
-    #     rm -rf *
+    - name: Create CLI Core Next Bundle
+      run: |
+        mkdir -p temp && cd temp
+        mkdir -p licenses && cd licenses && cp /tmp/zowe_licenses_full.zip zowe_licenses_full.zip && cd ..
+        npm pack @zowe/cli@next
+        mkdir -p packed && cd packed
+        for platform in linux macos windows; do
+          curl -fLOJ https://github.com/zowe/zowe-cli/releases/download/native-v${{ steps.versions.outputs.zowe-daemon }}/zowex-$platform.tgz
+        done && cd ..
+        bash ../scripts/repackage_bundle.sh *.tgz
+        mv zowe-cli-package.zip ../zowe-cli-package-${{ env.ZOWE_CLI_BUNDLE_NEXT_VERSION }}.zip
+        rm -rf *
     
-    # - name: Create CLI Plugins Next Bundle
-    #   run: |
-    #     mkdir -p temp && cd temp
-    #     mkdir -p licenses && cd licenses && cp /tmp/zowe_licenses_full.zip zowe_licenses_full.zip && cd ..
-    #     npm pack @zowe/cics-for-zowe-cli@next
-    #     npm pack @zowe/db2-for-zowe-cli@next
-    #     npm pack @zowe/ims-for-zowe-cli@next
-    #     npm pack @zowe/mq-for-zowe-cli@next
-    #     npm pack @zowe/zos-ftp-for-zowe-cli
-    #     bash ../scripts/repackage_bundle.sh *.tgz
-    #     mv zowe-cli-package.zip ../zowe-cli-plugins-${{ env.ZOWE_CLI_BUNDLE_NEXT_VERSION }}.zip
-    #     rm -rf *
+    - name: Create CLI Plugins Next Bundle
+      run: |
+        mkdir -p temp && cd temp
+        mkdir -p licenses && cd licenses && cp /tmp/zowe_licenses_full.zip zowe_licenses_full.zip && cd ..
+        npm pack @zowe/cics-for-zowe-cli@next
+        npm pack @zowe/db2-for-zowe-cli@next
+        npm pack @zowe/ims-for-zowe-cli@next
+        npm pack @zowe/mq-for-zowe-cli@next
+        npm pack @zowe/zos-ftp-for-zowe-cli
+        bash ../scripts/repackage_bundle.sh *.tgz
+        mv zowe-cli-package.zip ../zowe-cli-plugins-${{ env.ZOWE_CLI_BUNDLE_NEXT_VERSION }}.zip
+        rm -rf *
     
-    # - name: Create Node.js SDK Next Bundle
-    #   run: |
-    #     mkdir -p temp && cd temp
-    #     mkdir -p licenses && cd licenses && cp /tmp/zowe_licenses_full.zip zowe_licenses_full.zip && cd ..
-    #     npm pack @zowe/imperative@next
-    #     npm pack @zowe/core-for-zowe-sdk@next
-    #     npm pack @zowe/provisioning-for-zowe-sdk@next
-    #     npm pack @zowe/zos-console-for-zowe-sdk@next
-    #     npm pack @zowe/zos-files-for-zowe-sdk@next
-    #     npm pack @zowe/zos-jobs-for-zowe-sdk@next
-    #     npm pack @zowe/zos-tso-for-zowe-sdk@next
-    #     npm pack @zowe/zos-uss-for-zowe-sdk@next
-    #     npm pack @zowe/zos-workflows-for-zowe-sdk@next
-    #     npm pack @zowe/zosmf-for-zowe-sdk@next
-    #     bash ../scripts/repackage_bundle.sh *.tgz
-    #     mv zowe-cli-package.zip ../zowe-nodejs-sdk-${{ env.ZOWE_CLI_BUNDLE_NEXT_VERSION }}.zip
-    #     bash ../scripts/generate_typedoc.sh next
-    #     mv zowe-node-sdk-typedoc.zip ../zowe-nodejs-sdk-typedoc-${{ env.ZOWE_CLI_BUNDLE_NEXT_VERSION }}.zip
-    #     rm -rf *
+    - name: Create Node.js SDK Next Bundle
+      run: |
+        mkdir -p temp && cd temp
+        mkdir -p licenses && cd licenses && cp /tmp/zowe_licenses_full.zip zowe_licenses_full.zip && cd ..
+        npm pack @zowe/imperative@next
+        npm pack @zowe/core-for-zowe-sdk@next
+        npm pack @zowe/provisioning-for-zowe-sdk@next
+        npm pack @zowe/zos-console-for-zowe-sdk@next
+        npm pack @zowe/zos-files-for-zowe-sdk@next
+        npm pack @zowe/zos-jobs-for-zowe-sdk@next
+        npm pack @zowe/zos-tso-for-zowe-sdk@next
+        npm pack @zowe/zos-uss-for-zowe-sdk@next
+        npm pack @zowe/zos-workflows-for-zowe-sdk@next
+        npm pack @zowe/zosmf-for-zowe-sdk@next
+        bash ../scripts/repackage_bundle.sh *.tgz
+        mv zowe-cli-package.zip ../zowe-nodejs-sdk-${{ env.ZOWE_CLI_BUNDLE_NEXT_VERSION }}.zip
+        bash ../scripts/generate_typedoc.sh next
+        mv zowe-node-sdk-typedoc.zip ../zowe-nodejs-sdk-typedoc-${{ env.ZOWE_CLI_BUNDLE_NEXT_VERSION }}.zip
+        rm -rf *
     
-    # - name: Archive Build Artifacts
-    #   uses: actions/upload-artifact@v2
-    #   with:
-    #     name: 'zowe-cli-bundle'
-    #     path: '*.zip'
+    - name: Archive Build Artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        name: 'zowe-cli-bundle'
+        path: '*.zip'
 
-    # - name: Publish Bundles to Artifactory
-    #   if: ${{ github.event_name != 'pull_request' }}
-    #   run: |
-    #     jfrog rt u "zowe-cli-package-${{ env.ZOWE_CLI_BUNDLE_VERSION }}.zip" \
-    #       "${{ env.ARTIFACTORY_REPO }}/org/zowe/cli/zowe-cli-package/${{ env.ZOWE_CLI_BUNDLE_VERSION }}/"
-    #     jfrog rt u "zowe-cli-plugins-${{ env.ZOWE_CLI_BUNDLE_VERSION }}.zip" \
-    #       "${{ env.ARTIFACTORY_REPO }}/org/zowe/cli/zowe-cli-plugins/${{ env.ZOWE_CLI_BUNDLE_VERSION }}/"
-    #     jfrog rt u "zowe-nodejs-sdk*-${{ env.ZOWE_CLI_BUNDLE_VERSION }}.zip" \
-    #       "${{ env.ARTIFACTORY_REPO }}/org/zowe/sdk/zowe-nodejs-sdk/${{ env.ZOWE_CLI_BUNDLE_VERSION }}/"
-    #     jfrog rt u "zowe-python-sdk*-${{ env.ZOWE_CLI_BUNDLE_VERSION }}.zip" \
-    #       "${{ env.ARTIFACTORY_REPO }}/org/zowe/sdk/zowe-python-sdk/${{ env.ZOWE_CLI_BUNDLE_VERSION }}/"
-    #     jfrog rt u "zowe-cli-package-${{ env.ZOWE_CLI_BUNDLE_NEXT_VERSION }}.zip" \
-    #       "${{ env.ARTIFACTORY_REPO}}/org/zowe/cli/zowe-cli-package/next/"
-    #     jfrog rt u "zowe-cli-plugins-${{ env.ZOWE_CLI_BUNDLE_NEXT_VERSION }}.zip" \
-    #       "${{ env.ARTIFACTORY_REPO }}/org/zowe/cli/zowe-cli-plugins/next/"
-    #     jfrog rt u "zowe-nodejs-sdk*-${{ env.ZOWE_CLI_BUNDLE_NEXT_VERSION }}.zip" \
-    #       "${{ env.ARTIFACTORY_REPO }}/org/zowe/sdk/zowe-nodejs-sdk/next/"
+    - name: Publish Bundles to Artifactory
+      if: ${{ github.event_name != 'pull_request' }}
+      run: |
+        jfrog rt u "zowe-cli-package-${{ env.ZOWE_CLI_BUNDLE_VERSION }}.zip" \
+          "${{ env.ARTIFACTORY_REPO }}/org/zowe/cli/zowe-cli-package/${{ env.ZOWE_CLI_BUNDLE_VERSION }}/"
+        jfrog rt u "zowe-cli-plugins-${{ env.ZOWE_CLI_BUNDLE_VERSION }}.zip" \
+          "${{ env.ARTIFACTORY_REPO }}/org/zowe/cli/zowe-cli-plugins/${{ env.ZOWE_CLI_BUNDLE_VERSION }}/"
+        jfrog rt u "zowe-nodejs-sdk*-${{ env.ZOWE_CLI_BUNDLE_VERSION }}.zip" \
+          "${{ env.ARTIFACTORY_REPO }}/org/zowe/sdk/zowe-nodejs-sdk/${{ env.ZOWE_CLI_BUNDLE_VERSION }}/"
+        jfrog rt u "zowe-python-sdk*-${{ env.ZOWE_CLI_BUNDLE_VERSION }}.zip" \
+          "${{ env.ARTIFACTORY_REPO }}/org/zowe/sdk/zowe-python-sdk/${{ env.ZOWE_CLI_BUNDLE_VERSION }}/"
+        jfrog rt u "zowe-cli-package-${{ env.ZOWE_CLI_BUNDLE_NEXT_VERSION }}.zip" \
+          "${{ env.ARTIFACTORY_REPO}}/org/zowe/cli/zowe-cli-package/next/"
+        jfrog rt u "zowe-cli-plugins-${{ env.ZOWE_CLI_BUNDLE_NEXT_VERSION }}.zip" \
+          "${{ env.ARTIFACTORY_REPO }}/org/zowe/cli/zowe-cli-plugins/next/"
+        jfrog rt u "zowe-nodejs-sdk*-${{ env.ZOWE_CLI_BUNDLE_NEXT_VERSION }}.zip" \
+          "${{ env.ARTIFACTORY_REPO }}/org/zowe/sdk/zowe-nodejs-sdk/next/"

--- a/scripts/repackage_bundle.sh
+++ b/scripts/repackage_bundle.sh
@@ -24,7 +24,6 @@ do
 
     cd temp/package
     cp ../../../.npmrc .
-    echo Bravo && npm view @zowe/cli
 
     ## Extra work required to delete imperative prepare script
     ## This prevents Husky from erroring out - and it isn't needed if we aren't developing Imperative


### PR DESCRIPTION
Fixes an issue where the NPM registry was being used to fetch dependencies, instead of Zowe Artifactory.

As a result, on nights when the Zowe CLI Deploy All pipeline published a CLI package update to NPM, this workflow would run simultaneously, and sometimes fail to fetch an SDK package that had not been published yet.

For example, last night:
```
2021-10-14T00:13:01.3473936Z + cd temp/package
2021-10-14T00:13:01.3474721Z + cp ../../.npmrc .
2021-10-14T00:13:01.3489000Z cp: cannot stat '../../.npmrc': No such file or directory
2021-10-14T00:13:01.3489475Z + true
2021-10-14T00:13:01.3490160Z + [[ zowe-cli-6.35.0.tgz = *\i\m\p\e\r\a\t\i\v\e* ]]
2021-10-14T00:13:01.3491237Z + npm install --legacy-peer-deps --ignore-scripts
2021-10-14T00:13:18.5018507Z npm ERR! code ETARGET
2021-10-14T00:13:18.5044034Z npm ERR! notarget No matching version found for @zowe/zos-jobs-for-zowe-sdk@6.35.0.
2021-10-14T00:13:18.5045671Z npm ERR! notarget In most cases you or one of your dependencies are requesting
2021-10-14T00:13:18.5047055Z npm ERR! notarget a package version that doesn't exist.
```

This PR updates the repackage bundle script to copy the .npmrc file from the root of the repo, to ensure that the `@zowe:registry` setting gets propagated.