### PR TITLE
Fix scs bundle

### DIFF
--- a/scripts/repackage_bundle.sh
+++ b/scripts/repackage_bundle.sh
@@ -27,7 +27,7 @@ do
 
     ## Extra work required to delete imperative prepare script
     ## This prevents Husky from erroring out - and it isn't needed if we aren't developing Imperative
-    if [[ $tar = *"imperative"* ]]; then
+    if [[ $tar = *"imperative"* || $tar = *"secure-credential-store"* ]]; then
         node -e "package = require('./package.json');
                  delete package.scripts.prepare;
                  require('fs').writeFileSync('package.json', JSON.stringify(package, null, 2), 'utf8')"


### PR DESCRIPTION
Before:
`Create CLI Core LTS Bundle` failed
https://github.com/zowe/zowe-cli-standalone-package/runs/4654515580?check_suite_focus=true

After:
`Create CLI Core LTS Bundle` passed
https://github.com/zowe/zowe-cli-standalone-package/runs/4659767110?check_suite_focus=true

Notes:
- Build was cancelled to prevent any accidental publishing 😋 
- Step: `Set Release Variables` was temporarily commented out in a3c6986b0cbf2ca7d984f3334adf1c2096b51210
- Commit mentioned above was removed (force-pushed out)