### PR TITLE
Fix bugs in nightly deploy workflow

### DIFF
--- a/.github/workflows/zowe-cli-deploy-all.yaml
+++ b/.github/workflows/zowe-cli-deploy-all.yaml
@@ -71,7 +71,7 @@ jobs:
       if: ${{ failure() }}
       uses: JasonEtco/create-an-issue@v2
       env:
-        ERROR_REPORT: ${{ steps.deploy.outputs.error }}
+        ERROR_REPORT: ${{ steps.deploy.outputs.errors }}
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         WORKFLOW_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
       with:

--- a/.github/workflows/zowe-cli-deploy-all.yaml
+++ b/.github/workflows/zowe-cli-deploy-all.yaml
@@ -32,6 +32,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       max-parallel: 1
       matrix:
         package: ${{ fromJson(needs.build.outputs.deploy-matrix) }}

--- a/.github/workflows/zowe-cli-deploy-component.yaml
+++ b/.github/workflows/zowe-cli-deploy-component.yaml
@@ -48,7 +48,7 @@ jobs:
       if: ${{ failure() }}
       uses: JasonEtco/create-an-issue@v2
       env:
-        ERROR_REPORT: ${{ steps.deploy.outputs.error }}
+        ERROR_REPORT: ${{ steps.deploy.outputs.errors }}
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         WORKFLOW_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
       with:

--- a/issue-template.md
+++ b/issue-template.md
@@ -3,7 +3,7 @@ title: Failed to deploy @zowe/{{ env.PKG_NAME }}
 assignees: awharn, gejohnston, t1m0thyj, zFernand0
 labels: deploy-failed
 ---
-{{ env.WORKFLOW_URL }}
 ```yaml
 {{ env.ERROR_REPORT }}
 ```
+View workflow run: {{ env.WORKFLOW_URL }}

--- a/issue-template.md
+++ b/issue-template.md
@@ -4,6 +4,6 @@ assignees: awharn, gejohnston, t1m0thyj, zFernand0
 labels: deploy-failed
 ---
 {{ env.WORKFLOW_URL }}
-```json
+```yaml
 {{ env.ERROR_REPORT }}
 ```

--- a/scripts/deploy-component.js
+++ b/scripts/deploy-component.js
@@ -100,7 +100,7 @@ async function deploy(pkgName, pkgTag) {
     let taggedVersion;
     while (taggedVersion !== pkgVersion) {
         await delay(1000);
-        taggedVersion = (await exec.getExecOutput("npm", ["view", `${pkgScope}/${pkgName}@${pkgTag}`, "version"])).stdout.trim();
+        taggedVersion = (await exec.getExecOutput("npm", ["view", `${PKG_SCOPE}/${pkgName}@${pkgTag}`, "version"])).stdout.trim();
     }
 
     core.info("Verifying that deployed package can be installed");
@@ -130,6 +130,7 @@ async function deploy(pkgName, pkgTag) {
             await deploy(pkgName, pkgTag);
         } catch (err) {
             deployErrors[pkgTag] = err;
+            core.error(err);
         }
     }
 


### PR DESCRIPTION
* Prevented Deploy All workflow from aborting when just one component fails to deploy
* Fixed smoke test for `@next` tag failing because install directory was not isolated enough from where `@latest` smoke test runs
* Fixed `getPackageInfo` returning RC 0 and an empty string when `npm view @zowe/cli@XXX` is run for non-existent version
* Fixed empty error report in GitHub issue (https://github.com/zowe/zowe-cli-standalone-package/issues/63)