### PR TITLE
Update zowe-v2-lts versions and improve error handling for nightly deploy

### DIFF
--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -16,8 +16,8 @@ const fetch = require("node-fetch");
 const core = require("@actions/core");
 const exec = require("@actions/exec");
 
-async function execAndGetStderr(commandLine, args) {
-    const cmdOutput = await exec.getExecOutput(commandLine, args, { ignoreReturnCode: true });
+async function execAndGetStderr(commandLine, args, opts={}) {
+    const cmdOutput = await exec.getExecOutput(commandLine, args, { ignoreReturnCode: true, ...opts });
     if (cmdOutput.exitCode !== 0) {
         throw new Error(`The command '${commandLine} ${args.join(" ")}' failed with exit code ${cmdOutput.exitCode}\n${cmdOutput.stderr.trim()}`);
     }

--- a/zowe-versions.yaml
+++ b/zowe-versions.yaml
@@ -21,54 +21,54 @@ packages:
     zowe-v1-lts: 1.0.7
     next: false
   imperative:
-    zowe-v2-lts: 5.0.0
+    zowe-v2-lts: 5.0.2
     zowe-v1-lts: 4.18.1
     next: true
   cli-test-utils:
-    zowe-v2-lts: 7.0.0
+    zowe-v2-lts: 7.0.2
     next: true
   core-for-zowe-sdk:
-    zowe-v2-lts: 7.0.0
+    zowe-v2-lts: 7.0.2
     zowe-v1-lts: 6.38.0
     next: true
   zos-uss-for-zowe-sdk:
-    zowe-v2-lts: 7.0.0
+    zowe-v2-lts: 7.0.2
     zowe-v1-lts: 6.38.0
     next: true
   provisioning-for-zowe-sdk:
-    zowe-v2-lts: 7.0.0
+    zowe-v2-lts: 7.0.2
     zowe-v1-lts: 6.38.0
     next: true
   zos-console-for-zowe-sdk:
-    zowe-v2-lts: 7.0.0
+    zowe-v2-lts: 7.0.2
     zowe-v1-lts: 6.38.0
     next: true
   zos-files-for-zowe-sdk:
-    zowe-v2-lts: 7.0.0
+    zowe-v2-lts: 7.0.2
     zowe-v1-lts: 6.38.0
     next: true
   zos-logs-for-zowe-sdk:
-    zowe-v2-lts: 7.0.0
+    zowe-v2-lts: 7.0.2
     zowe-v1-lts: 6.38.0
     next: true
   zosmf-for-zowe-sdk:
-    zowe-v2-lts: 7.0.0
+    zowe-v2-lts: 7.0.2
     zowe-v1-lts: 6.38.0
     next: true
   zos-workflows-for-zowe-sdk:
-    zowe-v2-lts: 7.0.0
+    zowe-v2-lts: 7.0.2
     zowe-v1-lts: 6.38.0
     next: true
   zos-jobs-for-zowe-sdk:
-    zowe-v2-lts: 7.0.0
+    zowe-v2-lts: 7.0.2
     zowe-v1-lts: 6.38.0
     next: true
   zos-tso-for-zowe-sdk:
-    zowe-v2-lts: 7.0.0
+    zowe-v2-lts: 7.0.2
     zowe-v1-lts: 6.38.0
     next: true
   cli:
-    zowe-v2-lts: 7.0.0
+    zowe-v2-lts: 7.0.2
     zowe-v1-lts: 6.38.0
     next: true
   # CLI plug-ins
@@ -111,7 +111,7 @@ tags:
     rc: 1
   zowe-v2-lts:
     version: 2.0.0
-    rc: 1
+    rc: 2
   # next:
   #   version: 2.0.0
   #   snapshot: '2022-04-15'


### PR DESCRIPTION
Update `zowe-v2-lts` package versions.

Also fix error handling when smoke test fails:
* Catch stderr output of `npm install` to include in the auto-created issue
* Ignore errors thrown by the attempt to rollback (`npm dist-tag add`)

