### PR TITLE
Fix staging mode check for Zowe v2

### DIFF
--- a/.github/workflows/zowe-cli-bundle-all.yaml
+++ b/.github/workflows/zowe-cli-bundle-all.yaml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   build-v1-lts:
+    if: ${{ github.event_name == 'schedule' || !startsWith(github.ref_name, 'v2') }}
     uses: ./.github/workflows/zowe-cli-bundle.yaml
     secrets:
       JF_ARTIFACTORY_TOKEN: ${{ secrets.JF_ARTIFACTORY_TOKEN }}
@@ -19,6 +20,7 @@ jobs:
       release-type: snapshot
 
   build-v2-lts:
+    if: ${{ github.event_name == 'schedule' || !startsWith(github.ref_name, 'v1') }}
     uses: ./.github/workflows/zowe-cli-bundle.yaml
     secrets:
       JF_ARTIFACTORY_TOKEN: ${{ secrets.JF_ARTIFACTORY_TOKEN }}

--- a/.github/workflows/zowe-cli-bundle.yaml
+++ b/.github/workflows/zowe-cli-bundle.yaml
@@ -63,6 +63,8 @@ jobs:
     - name: Load Zowe Versions
       id: versions
       run: node scripts/load-zowe-versions.js ${{ github.event.inputs.package-tag || inputs.package-tag }} ${{ github.event.inputs.release-type || inputs.release-type }}
+      env:
+        GIT_BRANCH: ${{ github.ref_name }}
 
     - name: Setup JFrog CLI
       uses: jfrog/setup-jfrog-cli@v2

--- a/scripts/load-zowe-versions.js
+++ b/scripts/load-zowe-versions.js
@@ -19,6 +19,12 @@ const zoweVersions = jsYaml.load(fs.readFileSync(__dirname + "/../zowe-versions.
 const packageTag = process.argv[2];
 const releaseType = process.argv[3];
 
+// For branches named "vX.Y.Z/master", do not allow publishing LTS versions other than zowe-vX-lts
+if (packageTag !== "next" && process.env.GIT_BRANCH?.test(/^v\d/) &&
+    !packageTag.includes(process.env.GIT_BRANCH.slice(0, 2))) {
+    throw new Error(`Bundling ${packageTag} is not allowed in the ${process.env.GIT_BRANCH} branch`);
+}
+
 // Short version equals semver for Zowe LTS releases or "next" for vNext
 let bundleVersionShort = packageTag;
 if (packageTag !== "next") {

--- a/scripts/load-zowe-versions.js
+++ b/scripts/load-zowe-versions.js
@@ -20,7 +20,7 @@ const packageTag = process.argv[2];
 const releaseType = process.argv[3];
 
 // For branches named "vX.Y.Z/master", do not allow publishing LTS versions other than zowe-vX-lts
-if (packageTag !== "next" && process.env.GIT_BRANCH?.test(/^v\d/) &&
+if (packageTag !== "next" && /^v\d/.test(process.env.GIT_BRANCH) &&
     !packageTag.includes(process.env.GIT_BRANCH.slice(0, 2))) {
     throw new Error(`Bundling ${packageTag} is not allowed in the ${process.env.GIT_BRANCH} branch`);
 }

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -70,7 +70,7 @@ async function shouldSkipPublish(pkgName, pkgTag, pkgVersion) {
     const releasesData = jsYaml.load(await response.text());
 
     const zoweVersions = jsYaml.load(fs.readFileSync(__dirname + "/../zowe-versions.yaml", "utf-8"));
-    const isStaging = zoweVersions.tags["zowe-v1-lts"].version > releasesData[0].version;
+    const isStaging = zoweVersions.tags["zowe-v2-lts"].version > releasesData.v2[0].version;
     if (!isStaging || zoweVersions.packages[pkgName] == null) {
         return false;
     }
@@ -81,7 +81,7 @@ async function shouldSkipPublish(pkgName, pkgTag, pkgVersion) {
     }
 
     if (pkgTag !== "next") {
-        return pkgVersion > zoweVersions.packages[pkgName]["zowe-v1-lts"];
+        return pkgVersion > zoweVersions.packages[pkgName][pkgTag];
     } else {
         const dateString = pkgVersion.split(".").pop();
         const pkgDate = moment(`${dateString.slice(0, 4)}-${dateString.slice(4, 6)}-${dateString.slice(6, 8)}`);

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -70,8 +70,9 @@ async function shouldSkipPublish(pkgName, pkgTag, pkgVersion) {
     const releasesData = jsYaml.load(await response.text());
 
     const zoweVersions = jsYaml.load(fs.readFileSync(__dirname + "/../zowe-versions.yaml", "utf-8"));
-    const isStaging = zoweVersions.tags["zowe-v2-lts"].version > releasesData.v2[0].version;
-    if (!isStaging || zoweVersions.packages[pkgName] == null) {
+    const ourBundleVersion = zoweVersions.tags[pkgTag.endsWith("-lts") ? pkgTag : "zowe-v2-lts"].version;
+    const theirBundleVersion = releasesData[`v${ourBundleVersion[0]}`][0].version;
+    if (ourBundleVersion <= theirBundleVersion || zoweVersions.packages[pkgName] == null) {
         return false;
     }
 


### PR DESCRIPTION
* Fix deployment freeze to handle Zowe v1 and v2 separately
* Validate that bundle tag (e.g. zowe-**v2**-lts) matches Git branch name (e.g., **v2**.0.0/master)