### PR TITLE
Fix nightly deploy

### DIFF
--- a/.github/deploy-failed.md
+++ b/.github/deploy-failed.md
@@ -1,8 +1,8 @@
 ---
 title: Failed to deploy @zowe/{{ env.PKG_NAME }}
-assignees: awharn, gejohnston, t1m0thyj, zFernand0
 labels: deploy-failed
 ---
+@zowe/zowe-cli-administrators
 ```
 {{ env.ERROR_REPORT }}
 ```

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -83,6 +83,8 @@ async function shouldSkipPublish(pkgName, pkgTag, pkgVersion) {
 
     if (pkgTag !== "next") {
         return pkgVersion > zoweVersions.packages[pkgName][pkgTag];
+    } else if (zoweVersions.tags.next == null) {
+        return false;  // If there is no prerelease version, then always publish the latest version to @next
     } else {
         const dateString = pkgVersion.split(".").pop();
         const pkgDate = moment(`${dateString.slice(0, 4)}-${dateString.slice(4, 6)}-${dateString.slice(6, 8)}`);

--- a/zowe-versions.yaml
+++ b/zowe-versions.yaml
@@ -21,54 +21,54 @@ packages:
     zowe-v1-lts: 1.0.7
     next: false
   imperative:
-    zowe-v2-lts: 5.0.2
+    zowe-v2-lts: 5.3.2
     zowe-v1-lts: 4.18.6
     next: true
   cli-test-utils:
-    zowe-v2-lts: 7.0.2
+    zowe-v2-lts: 7.2.2
     next: true
   core-for-zowe-sdk:
-    zowe-v2-lts: 7.0.2
+    zowe-v2-lts: 7.2.2
     zowe-v1-lts: 6.40.4
     next: true
   zos-uss-for-zowe-sdk:
-    zowe-v2-lts: 7.0.2
+    zowe-v2-lts: 7.2.2
     zowe-v1-lts: 6.40.4
     next: true
   provisioning-for-zowe-sdk:
-    zowe-v2-lts: 7.0.2
+    zowe-v2-lts: 7.2.2
     zowe-v1-lts: 6.40.4
     next: true
   zos-console-for-zowe-sdk:
-    zowe-v2-lts: 7.0.2
+    zowe-v2-lts: 7.2.2
     zowe-v1-lts: 6.40.4
     next: true
   zos-files-for-zowe-sdk:
-    zowe-v2-lts: 7.0.2
+    zowe-v2-lts: 7.2.2
     zowe-v1-lts: 6.40.4
     next: true
   zos-logs-for-zowe-sdk:
-    zowe-v2-lts: 7.0.2
+    zowe-v2-lts: 7.2.2
     zowe-v1-lts: 6.40.4
     next: true
   zosmf-for-zowe-sdk:
-    zowe-v2-lts: 7.0.2
+    zowe-v2-lts: 7.2.2
     zowe-v1-lts: 6.40.4
     next: true
   zos-workflows-for-zowe-sdk:
-    zowe-v2-lts: 7.0.2
+    zowe-v2-lts: 7.2.2
     zowe-v1-lts: 6.40.4
     next: true
   zos-jobs-for-zowe-sdk:
-    zowe-v2-lts: 7.0.2
+    zowe-v2-lts: 7.2.2
     zowe-v1-lts: 6.40.4
     next: true
   zos-tso-for-zowe-sdk:
-    zowe-v2-lts: 7.0.2
+    zowe-v2-lts: 7.2.2
     zowe-v1-lts: 6.40.4
     next: true
   cli:
-    zowe-v2-lts: 7.0.2
+    zowe-v2-lts: 7.2.2
     zowe-v1-lts: 6.40.4
     next: true
   # CLI plug-ins
@@ -110,8 +110,8 @@ tags:
     version: 1.28.0
     rc: 1
   zowe-v2-lts:
-    version: 2.0.0
-    rc: 2
+    version: 2.1.0
+    rc: 1
   # next:
   #   version: 2.0.0
   #   snapshot: '2022-04-15'


### PR DESCRIPTION
* If there is no prerelease version, then always publish the latest version to `@next`, even in "staging mode"
* Tag the `@zowe/zowe-cli-adminstrators` group on `deploy-failed` issues instead of assigning people