### PR TITLE
Update component versions for Zowe 1.28.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,29 +12,13 @@ Before every Zowe release goes GA, we need to align with the code freeze dates a
     - Update release number to match the RC that's going out (e.g. 1.22.0)
     - Update any packages that changed after the last Zowe Release.
     - Add a summary of the changes in the PR description like below:
-      ```yaml
-      zowe-cli:
-        imperative: 4.13.0 -> 4.13.1
-        perf-timing: 1.0.7
-        cli: 6.31.0 -> 6.31.1
-      zowe-plugins:
-        cics: 4.0.2
-        db2: 4.1.0
-        ims: 2.0.1
-        mq: 2.0.1
-        secure-credential-store: 4.1.3 -> 4.1.5
-        zos-ftp: 1.4.1 -> 1.6.0
-      zowe-sdk:
-        core: 6.31.0 -> 6.31.1
-        provisioning: 6.31.0 -> 6.31.1
-        zos-console: 6.31.0 -> 6.31.1
-        zos-files: 6.31.0 -> 6.31.1
-        zos-jobs: 6.31.0 -> 6.31.1
-        zos-tso: 6.31.0 -> 6.31.1
-        zos-uss: 6.30.0 -> 6.31.1
-        zos-workflows: 6.31.0 -> 6.31.1
-        zosmf: 6.31.0 -> 6.31.1
-        ```
+      | Updated Packages | Old Version | New Version |
+      | --- | --- | --- |
+      | Imperative | 4.13.0 | 4.13.1 |
+      | Zowe CLI and SDKs | 6.31.0 | 6.31.1 |
+      | z/OS USS SDK for Zowe CLI | 6.30.0 | 6.31.1 |
+      | SCS plug-in for Zowe CLI | 4.1.3 | 4.1.5 |
+      | z/OS FTP plug-in for Zowe CLI | 1.4.1 | 1.6.0 |
 2. Check to see if the `master` build failed due to missing licenses.
     - If so, rerun the workflow and change the license URL to a previous version
 3. Notify `Tom Zhang` on Slack and make sure to copy a link to the PR and the build that uploaded the bundles to `libs-snapshot-local` on JFrog Artifactory

--- a/zowe-versions.yaml
+++ b/zowe-versions.yaml
@@ -29,47 +29,47 @@ packages:
     next: true
   core-for-zowe-sdk:
     zowe-v2-lts: 7.3.1
-    zowe-v1-lts: 6.40.5
+    zowe-v1-lts: 6.40.6
     next: true
   zos-uss-for-zowe-sdk:
     zowe-v2-lts: 7.3.1
-    zowe-v1-lts: 6.40.5
+    zowe-v1-lts: 6.40.6
     next: true
   provisioning-for-zowe-sdk:
     zowe-v2-lts: 7.3.1
-    zowe-v1-lts: 6.40.5
+    zowe-v1-lts: 6.40.6
     next: true
   zos-console-for-zowe-sdk:
     zowe-v2-lts: 7.3.1
-    zowe-v1-lts: 6.40.5
+    zowe-v1-lts: 6.40.6
     next: true
   zos-files-for-zowe-sdk:
     zowe-v2-lts: 7.3.1
-    zowe-v1-lts: 6.40.5
+    zowe-v1-lts: 6.40.6
     next: true
   zos-logs-for-zowe-sdk:
     zowe-v2-lts: 7.3.1
-    zowe-v1-lts: 6.40.5
+    zowe-v1-lts: 6.40.6
     next: true
   zosmf-for-zowe-sdk:
     zowe-v2-lts: 7.3.1
-    zowe-v1-lts: 6.40.5
+    zowe-v1-lts: 6.40.6
     next: true
   zos-workflows-for-zowe-sdk:
     zowe-v2-lts: 7.3.1
-    zowe-v1-lts: 6.40.5
+    zowe-v1-lts: 6.40.6
     next: true
   zos-jobs-for-zowe-sdk:
     zowe-v2-lts: 7.3.1
-    zowe-v1-lts: 6.40.5
+    zowe-v1-lts: 6.40.6
     next: true
   zos-tso-for-zowe-sdk:
     zowe-v2-lts: 7.3.1
-    zowe-v1-lts: 6.40.5
+    zowe-v1-lts: 6.40.6
     next: true
   cli:
     zowe-v2-lts: 7.4.0
-    zowe-v1-lts: 6.40.5
+    zowe-v1-lts: 6.40.6
     next: true
   # CLI plug-ins
   cics-for-zowe-cli:

--- a/zowe-versions.yaml
+++ b/zowe-versions.yaml
@@ -22,54 +22,54 @@ packages:
     next: false
   imperative:
     zowe-v2-lts: 5.3.5
-    zowe-v1-lts: 4.18.6
+    zowe-v1-lts: 4.18.8
     next: true
   cli-test-utils:
     zowe-v2-lts: 7.3.1
     next: true
   core-for-zowe-sdk:
     zowe-v2-lts: 7.3.1
-    zowe-v1-lts: 6.40.4
+    zowe-v1-lts: 6.40.5
     next: true
   zos-uss-for-zowe-sdk:
     zowe-v2-lts: 7.3.1
-    zowe-v1-lts: 6.40.4
+    zowe-v1-lts: 6.40.5
     next: true
   provisioning-for-zowe-sdk:
     zowe-v2-lts: 7.3.1
-    zowe-v1-lts: 6.40.4
+    zowe-v1-lts: 6.40.5
     next: true
   zos-console-for-zowe-sdk:
     zowe-v2-lts: 7.3.1
-    zowe-v1-lts: 6.40.4
+    zowe-v1-lts: 6.40.5
     next: true
   zos-files-for-zowe-sdk:
     zowe-v2-lts: 7.3.1
-    zowe-v1-lts: 6.40.4
+    zowe-v1-lts: 6.40.5
     next: true
   zos-logs-for-zowe-sdk:
     zowe-v2-lts: 7.3.1
-    zowe-v1-lts: 6.40.4
+    zowe-v1-lts: 6.40.5
     next: true
   zosmf-for-zowe-sdk:
     zowe-v2-lts: 7.3.1
-    zowe-v1-lts: 6.40.4
+    zowe-v1-lts: 6.40.5
     next: true
   zos-workflows-for-zowe-sdk:
     zowe-v2-lts: 7.3.1
-    zowe-v1-lts: 6.40.4
+    zowe-v1-lts: 6.40.5
     next: true
   zos-jobs-for-zowe-sdk:
     zowe-v2-lts: 7.3.1
-    zowe-v1-lts: 6.40.4
+    zowe-v1-lts: 6.40.5
     next: true
   zos-tso-for-zowe-sdk:
     zowe-v2-lts: 7.3.1
-    zowe-v1-lts: 6.40.4
+    zowe-v1-lts: 6.40.5
     next: true
   cli:
     zowe-v2-lts: 7.4.0
-    zowe-v1-lts: 6.40.4
+    zowe-v1-lts: 6.40.5
     next: true
   # CLI plug-ins
   cics-for-zowe-cli:
@@ -78,7 +78,7 @@ packages:
     next: true
   db2-for-zowe-cli:
     zowe-v2-lts: 5.0.0
-    zowe-v1-lts: 4.1.6
+    zowe-v1-lts: 4.1.7
     next: true
   ims-for-zowe-cli:
     zowe-v2-lts: 3.0.0
@@ -107,7 +107,7 @@ extras:
 # Define version info for the latest staged Zowe release.
 tags:
   zowe-v1-lts:
-    version: 1.28.0
+    version: 1.28.1
     rc: 1
   zowe-v2-lts:
     version: 2.2.0

--- a/zowe-versions.yaml
+++ b/zowe-versions.yaml
@@ -108,7 +108,7 @@ extras:
 tags:
   zowe-v1-lts:
     version: 1.28.1
-    rc: 1
+    rc: 2
   zowe-v2-lts:
     version: 2.2.0
     rc: 1


### PR DESCRIPTION
| Updated Packages | Old Version | New Version |
| --- | --- | --- |
| Imperative | 4.18.6 | 4.18.8 |
| Zowe CLI and SDKs | 6.40.4 | 6.40.6 |
| DB2 plug-in for Zowe CLI | 4.1.6 | 4.1.7 |
