### PR TITLE
Update component versions for Zowe 2.5.0

### DIFF
--- a/zowe-versions.yaml
+++ b/zowe-versions.yaml
@@ -21,54 +21,54 @@ packages:
     zowe-v1-lts: 1.0.7
     next: false
   imperative:
-    zowe-v2-lts: 5.5.4
+    zowe-v2-lts: 5.7.2
     zowe-v1-lts: 4.18.11
     next: true
   cli-test-utils:
-    zowe-v2-lts: 7.6.2
+    zowe-v2-lts: 7.9.0
     next: true
   core-for-zowe-sdk:
-    zowe-v2-lts: 7.6.2
+    zowe-v2-lts: 7.9.0
     zowe-v1-lts: 6.40.10
     next: true
   zos-uss-for-zowe-sdk:
-    zowe-v2-lts: 7.6.2
+    zowe-v2-lts: 7.9.0
     zowe-v1-lts: 6.40.10
     next: true
   provisioning-for-zowe-sdk:
-    zowe-v2-lts: 7.6.2
+    zowe-v2-lts: 7.9.0
     zowe-v1-lts: 6.40.10
     next: true
   zos-console-for-zowe-sdk:
-    zowe-v2-lts: 7.6.2
+    zowe-v2-lts: 7.9.0
     zowe-v1-lts: 6.40.10
     next: true
   zos-files-for-zowe-sdk:
-    zowe-v2-lts: 7.6.2
+    zowe-v2-lts: 7.9.0
     zowe-v1-lts: 6.40.10
     next: true
   zos-logs-for-zowe-sdk:
-    zowe-v2-lts: 7.6.2
+    zowe-v2-lts: 7.9.0
     zowe-v1-lts: 6.40.10
     next: true
   zosmf-for-zowe-sdk:
-    zowe-v2-lts: 7.6.2
+    zowe-v2-lts: 7.9.0
     zowe-v1-lts: 6.40.10
     next: true
   zos-workflows-for-zowe-sdk:
-    zowe-v2-lts: 7.6.2
+    zowe-v2-lts: 7.9.0
     zowe-v1-lts: 6.40.10
     next: true
   zos-jobs-for-zowe-sdk:
-    zowe-v2-lts: 7.6.2
+    zowe-v2-lts: 7.9.0
     zowe-v1-lts: 6.40.10
     next: true
   zos-tso-for-zowe-sdk:
-    zowe-v2-lts: 7.6.2
+    zowe-v2-lts: 7.9.0
     zowe-v1-lts: 6.40.10
     next: true
   cli:
-    zowe-v2-lts: 7.6.2
+    zowe-v2-lts: 7.9.0
     zowe-v1-lts: 6.40.10
     next: true
   # CLI plug-ins
@@ -110,7 +110,7 @@ tags:
     version: 1.28.2
     rc: 2
   zowe-v2-lts:
-    version: 2.4.0
+    version: 2.5.0
     rc: 1
   # next:
   #   version: 2.0.0


### PR DESCRIPTION
| Updated Packages | Old Version | New Version |
| --- | --- | --- |
| Imperative | 5.5.4 | 5.7.2 |
| Zowe CLI and SDKs | 7.6.2 | 7.9.0 |