### PR TITLE
Fix issues with deployment workflows

### DIFF
--- a/scripts/repackage_tar.sh
+++ b/scripts/repackage_tar.sh
@@ -42,7 +42,8 @@ mv package_new.json package.json
 
 # Check that all dependencies are valid
 npmDeps=`node -e "package = require('./package.json');
-    Object.entries(package.dependencies || {}).forEach(([name, version]) => console.log(name + '@' + version));"`
+    Object.entries(package.dependencies || {}).forEach(([name, version]) => console.log(name + '@' + version));
+    Object.entries(package.peerDependencies || {}).forEach(([name, version]) => console.log(name + '@' + version));"`
 for pkgSpec in $npmDeps; do
     echo "Validating dependency $pkgSpec..."
     npm view $pkgSpec || exit 1


### PR DESCRIPTION
* [x] Check that peer deps are valid before nightly deployment
* [x] Allow specific version number as PKG_TAG input
  * [x] Bypass `shouldSkipPublish` check if PKG_TAG is semver instead of tag
  * [x] Don't tag package as `@latest`, instead use a temporary tag (`@untagged` 😄) since npm forces us to and delete it ASAP