### PR TITLE
Update component versions for Zowe 2.6.0

### DIFF
--- a/.github/workflows/zowe-cli-bundle.yaml
+++ b/.github/workflows/zowe-cli-bundle.yaml
@@ -135,7 +135,7 @@ jobs:
         mkdir -p temp && cd temp
         mkdir -p licenses && cd licenses && cp /tmp/zowe_licenses_cli.zip zowe_licenses_cli.zip && cd ..
         pip3 download --no-binary=pyyaml zowe
-        zip -r zowe-sdk.zip *
+        zip -rX zowe-sdk.zip *
         mv zowe-sdk.zip ../zowe-python-sdk-${{ env.BUNDLE_VERSION }}.zip
         rm -rf *
 

--- a/scripts/generate_typedoc.sh
+++ b/scripts/generate_typedoc.sh
@@ -88,4 +88,4 @@ EOF
 
 # Build typedoc and zip it up
 npx typedoc ./node_modules/@zowe
-zip -r ../zowe-node-sdk-typedoc.zip typedoc
+zip -rX ../zowe-node-sdk-typedoc.zip typedoc

--- a/scripts/repackage_bundle.sh
+++ b/scripts/repackage_bundle.sh
@@ -84,6 +84,6 @@ cd packed
 # rename 's/brightside\-core*/zowe\-cli/' *
 # rename 's/brightside\-cics*/zowe\-cics/' *
 # rename 's/brightside\-db2*/zowe\-db2/' *
-zip -r zowe-cli-package.zip *
+zip -rX zowe-cli-package.zip *
 mv zowe-cli-package.zip ../zowe-cli-package.zip
 rm -rf *.tgz

--- a/zowe-versions.yaml
+++ b/zowe-versions.yaml
@@ -21,54 +21,54 @@ packages:
     zowe-v1-lts: 1.0.7
     next: false
   imperative:
-    zowe-v2-lts: 5.7.2
+    zowe-v2-lts: 5.7.7
     zowe-v1-lts: 4.18.11
     next: true
   cli-test-utils:
-    zowe-v2-lts: 7.9.0
+    zowe-v2-lts: 7.9.7
     next: true
   core-for-zowe-sdk:
-    zowe-v2-lts: 7.9.0
+    zowe-v2-lts: 7.9.7
     zowe-v1-lts: 6.40.10
     next: true
   zos-uss-for-zowe-sdk:
-    zowe-v2-lts: 7.9.0
+    zowe-v2-lts: 7.9.7
     zowe-v1-lts: 6.40.10
     next: true
   provisioning-for-zowe-sdk:
-    zowe-v2-lts: 7.9.0
+    zowe-v2-lts: 7.9.7
     zowe-v1-lts: 6.40.10
     next: true
   zos-console-for-zowe-sdk:
-    zowe-v2-lts: 7.9.0
+    zowe-v2-lts: 7.9.7
     zowe-v1-lts: 6.40.10
     next: true
   zos-files-for-zowe-sdk:
-    zowe-v2-lts: 7.9.0
+    zowe-v2-lts: 7.9.7
     zowe-v1-lts: 6.40.10
     next: true
   zos-logs-for-zowe-sdk:
-    zowe-v2-lts: 7.9.0
+    zowe-v2-lts: 7.9.7
     zowe-v1-lts: 6.40.10
     next: true
   zosmf-for-zowe-sdk:
-    zowe-v2-lts: 7.9.0
+    zowe-v2-lts: 7.9.7
     zowe-v1-lts: 6.40.10
     next: true
   zos-workflows-for-zowe-sdk:
-    zowe-v2-lts: 7.9.0
+    zowe-v2-lts: 7.9.7
     zowe-v1-lts: 6.40.10
     next: true
   zos-jobs-for-zowe-sdk:
-    zowe-v2-lts: 7.9.1
+    zowe-v2-lts: 7.9.7
     zowe-v1-lts: 6.40.10
     next: true
   zos-tso-for-zowe-sdk:
-    zowe-v2-lts: 7.9.0
+    zowe-v2-lts: 7.9.7
     zowe-v1-lts: 6.40.10
     next: true
   cli:
-    zowe-v2-lts: 7.9.1
+    zowe-v2-lts: 7.9.7
     zowe-v1-lts: 6.40.10
     next: true
   # CLI plug-ins
@@ -92,7 +92,7 @@ packages:
     zowe-v1-lts: 4.1.10
     next: false
   zos-ftp-for-zowe-cli:
-    zowe-v2-lts: 2.1.0
+    zowe-v2-lts: 2.1.1
     zowe-v1-lts: 1.8.7
     next: true
 
@@ -110,8 +110,8 @@ tags:
     version: 1.28.2
     rc: 2
   zowe-v2-lts:
-    version: 2.5.0
-    rc: 2
+    version: 2.6.0
+    rc: 1
   # next:
   #   version: 2.0.0
   #   snapshot: '2022-04-15'


### PR DESCRIPTION
| Updated Packages | Old Version | New Version |
| --- | --- | --- |
| Imperative | 5.7.2 | 5.7.7 |
| Zowe CLI and SDKs | 7.9.0 | 7.9.7 |
| z/OS FTP plug-in for Zowe CLI | 2.1.0 | 2.1.1 |