### PR TITLE
Try to Reproduce Builds

### DIFF
--- a/.github/workflows/zowe-cli-bundle.yaml
+++ b/.github/workflows/zowe-cli-bundle.yaml
@@ -135,8 +135,10 @@ jobs:
         mkdir -p temp && cd temp
         mkdir -p licenses && cd licenses && cp /tmp/zowe_licenses_cli.zip zowe_licenses_cli.zip && cd ..
         pip3 download --no-binary=pyyaml zowe
-        zip -rX zowe-sdk.zip *
+        TZ=UTC find . -exec touch -t 197001010000.00 {} +
+        TZ=UTC zip -roX zowe-sdk.zip *
         mv zowe-sdk.zip ../zowe-python-sdk-${{ env.BUNDLE_VERSION }}.zip
+        TZ=UTC touch -t 197001010000.00 ../zowe-python-sdk-${{ env.BUNDLE_VERSION }}.zip
         rm -rf *
 
     - name: Archive Build Artifacts

--- a/.github/workflows/zowe-cli-bundle.yaml
+++ b/.github/workflows/zowe-cli-bundle.yaml
@@ -141,6 +141,9 @@ jobs:
         TZ=UTC touch -t 197001010000.00 ../zowe-python-sdk-${{ env.BUNDLE_VERSION }}.zip
         rm -rf *
 
+    - name: Update Timestamps
+      run: TZ=UTC find . -maxdepth 1 -name "*.zip" -type f -exec touch -t 197001010000.00 {} +
+
     - name: Archive Build Artifacts
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/zowe-cli-bundle.yaml
+++ b/.github/workflows/zowe-cli-bundle.yaml
@@ -138,7 +138,6 @@ jobs:
         TZ=UTC find . -exec touch -t 197001010000.00 {} +
         TZ=UTC zip -roX zowe-sdk.zip *
         mv zowe-sdk.zip ../zowe-python-sdk-${{ env.BUNDLE_VERSION }}.zip
-        TZ=UTC touch -t 197001010000.00 ../zowe-python-sdk-${{ env.BUNDLE_VERSION }}.zip
         rm -rf *
 
     - name: Update Timestamps

--- a/scripts/generate_typedoc.sh
+++ b/scripts/generate_typedoc.sh
@@ -91,4 +91,3 @@ npx typedoc ./node_modules/@zowe
 TZ=UTC find typedoc/ -exec touch -t 197001010000.00 {} +
 TZ=UTC touch -t 197001010000.00 typedoc
 TZ=UTC zip -roX ../zowe-node-sdk-typedoc.zip typedoc
-TZ=UTC touch -t 197001010000.00 ../zowe-node-sdk-typedoc.zip

--- a/scripts/generate_typedoc.sh
+++ b/scripts/generate_typedoc.sh
@@ -88,4 +88,7 @@ EOF
 
 # Build typedoc and zip it up
 npx typedoc ./node_modules/@zowe
-zip -rX ../zowe-node-sdk-typedoc.zip typedoc
+TZ=UTC find typedoc/ -exec touch -t 197001010000.00 {} +
+TZ=UTC touch -t 197001010000.00 typedoc
+TZ=UTC zip -roX ../zowe-node-sdk-typedoc.zip typedoc
+TZ=UTC touch -t 197001010000.00 ../zowe-node-sdk-typedoc.zip

--- a/scripts/repackage_bundle.sh
+++ b/scripts/repackage_bundle.sh
@@ -87,6 +87,4 @@ cd packed
 # Set all timestamps for files and directories to Jan 1 1970 00:00:00 UTC
 TZ=UTC find . -exec touch -t 197001010000.00 {} +
 TZ=UTC zip -roX ../zowe-cli-package.zip *
-TZ=UTC touch -t 197001010000.00 ../zowe-cli-package.zip
-# mv zowe-cli-package.zip ../zowe-cli-package.zip
 rm -rf *.tgz

--- a/scripts/repackage_bundle.sh
+++ b/scripts/repackage_bundle.sh
@@ -84,6 +84,9 @@ cd packed
 # rename 's/brightside\-core*/zowe\-cli/' *
 # rename 's/brightside\-cics*/zowe\-cics/' *
 # rename 's/brightside\-db2*/zowe\-db2/' *
-zip -rX zowe-cli-package.zip *
-mv zowe-cli-package.zip ../zowe-cli-package.zip
+# Set all timestamps for files and directories to Jan 1 1970 00:00:00 UTC
+TZ=UTC find . -exec touch -t 197001010000.00 {} +
+TZ=UTC zip -roX ../zowe-cli-package.zip *
+TZ=UTC touch -t 197001010000.00 ../zowe-cli-package.zip
+# mv zowe-cli-package.zip ../zowe-cli-package.zip
 rm -rf *.tgz


### PR DESCRIPTION
Implements some changes to make builds more reproducible. This includes:
- Changing file modification times to Linux epoch (Jan 1 1970 00:00:00 UTC) prior to ZIPing the files up
- Removing extra time data from ZIP files

Note that this only seems to work for Artifactory. GitHub Actions seems to put the current time in the artifacts that are uploaded to GitHub, and does not seem to provide a way to override this behavior. 😢 