### PR TITLE
Update component versions for Zowe 2.6.1

### DIFF
--- a/zowe-versions.yaml
+++ b/zowe-versions.yaml
@@ -68,7 +68,7 @@ packages:
     zowe-v1-lts: 6.40.10
     next: true
   cli:
-    zowe-v2-lts: 7.9.7
+    zowe-v2-lts: 7.9.8
     zowe-v1-lts: 6.40.10
     next: true
   # CLI plug-ins
@@ -110,8 +110,8 @@ tags:
     version: 1.28.2
     rc: 2
   zowe-v2-lts:
-    version: 2.6.0
-    rc: 2
+    version: 2.6.1
+    rc: 1
   # next:
   #   version: 2.0.0
   #   snapshot: '2022-04-15'


### PR DESCRIPTION
The only change since 2.6.0 is a patch update for Zowe CLI (7.9.7 -> 7.9.8).

**Note:** The build will fail until a license zip for 2.6.1 is available.