### PR TITLE
Update component versions for Zowe 2.7.0

### DIFF
--- a/zowe-versions.yaml
+++ b/zowe-versions.yaml
@@ -21,54 +21,54 @@ packages:
     zowe-v1-lts: 1.0.7
     next: false
   imperative:
-    zowe-v2-lts: 5.8.3
+    zowe-v2-lts: 5.9.0
     zowe-v1-lts: 4.18.11
     next: true
   cli-test-utils:
-    zowe-v2-lts: 7.10.4
+    zowe-v2-lts: 7.11.0
     next: true
   core-for-zowe-sdk:
-    zowe-v2-lts: 7.10.4
+    zowe-v2-lts: 7.11.0
     zowe-v1-lts: 6.40.10
     next: true
   zos-uss-for-zowe-sdk:
-    zowe-v2-lts: 7.10.4
+    zowe-v2-lts: 7.11.0
     zowe-v1-lts: 6.40.10
     next: true
   provisioning-for-zowe-sdk:
-    zowe-v2-lts: 7.10.4
+    zowe-v2-lts: 7.11.0
     zowe-v1-lts: 6.40.10
     next: true
   zos-console-for-zowe-sdk:
-    zowe-v2-lts: 7.10.4
+    zowe-v2-lts: 7.11.0
     zowe-v1-lts: 6.40.10
     next: true
   zos-files-for-zowe-sdk:
-    zowe-v2-lts: 7.10.4
+    zowe-v2-lts: 7.11.0
     zowe-v1-lts: 6.40.10
     next: true
   zos-logs-for-zowe-sdk:
-    zowe-v2-lts: 7.10.4
+    zowe-v2-lts: 7.11.0
     zowe-v1-lts: 6.40.10
     next: true
   zosmf-for-zowe-sdk:
-    zowe-v2-lts: 7.10.4
+    zowe-v2-lts: 7.11.0
     zowe-v1-lts: 6.40.10
     next: true
   zos-workflows-for-zowe-sdk:
-    zowe-v2-lts: 7.10.4
+    zowe-v2-lts: 7.11.0
     zowe-v1-lts: 6.40.10
     next: true
   zos-jobs-for-zowe-sdk:
-    zowe-v2-lts: 7.10.4
+    zowe-v2-lts: 7.11.0
     zowe-v1-lts: 6.40.10
     next: true
   zos-tso-for-zowe-sdk:
-    zowe-v2-lts: 7.10.4
+    zowe-v2-lts: 7.11.0
     zowe-v1-lts: 6.40.10
     next: true
   cli:
-    zowe-v2-lts: 7.10.4
+    zowe-v2-lts: 7.11.0
     zowe-v1-lts: 6.40.10
     next: true
   # CLI plug-ins

--- a/zowe-versions.yaml
+++ b/zowe-versions.yaml
@@ -21,54 +21,54 @@ packages:
     zowe-v1-lts: 1.0.7
     next: false
   imperative:
-    zowe-v2-lts: 5.7.7
+    zowe-v2-lts: 5.8.3
     zowe-v1-lts: 4.18.11
     next: true
   cli-test-utils:
-    zowe-v2-lts: 7.9.7
+    zowe-v2-lts: 7.10.4
     next: true
   core-for-zowe-sdk:
-    zowe-v2-lts: 7.9.7
+    zowe-v2-lts: 7.10.4
     zowe-v1-lts: 6.40.10
     next: true
   zos-uss-for-zowe-sdk:
-    zowe-v2-lts: 7.9.7
+    zowe-v2-lts: 7.10.4
     zowe-v1-lts: 6.40.10
     next: true
   provisioning-for-zowe-sdk:
-    zowe-v2-lts: 7.9.7
+    zowe-v2-lts: 7.10.4
     zowe-v1-lts: 6.40.10
     next: true
   zos-console-for-zowe-sdk:
-    zowe-v2-lts: 7.9.7
+    zowe-v2-lts: 7.10.4
     zowe-v1-lts: 6.40.10
     next: true
   zos-files-for-zowe-sdk:
-    zowe-v2-lts: 7.9.7
+    zowe-v2-lts: 7.10.4
     zowe-v1-lts: 6.40.10
     next: true
   zos-logs-for-zowe-sdk:
-    zowe-v2-lts: 7.9.7
+    zowe-v2-lts: 7.10.4
     zowe-v1-lts: 6.40.10
     next: true
   zosmf-for-zowe-sdk:
-    zowe-v2-lts: 7.9.7
+    zowe-v2-lts: 7.10.4
     zowe-v1-lts: 6.40.10
     next: true
   zos-workflows-for-zowe-sdk:
-    zowe-v2-lts: 7.9.7
+    zowe-v2-lts: 7.10.4
     zowe-v1-lts: 6.40.10
     next: true
   zos-jobs-for-zowe-sdk:
-    zowe-v2-lts: 7.9.7
+    zowe-v2-lts: 7.10.4
     zowe-v1-lts: 6.40.10
     next: true
   zos-tso-for-zowe-sdk:
-    zowe-v2-lts: 7.9.7
+    zowe-v2-lts: 7.10.4
     zowe-v1-lts: 6.40.10
     next: true
   cli:
-    zowe-v2-lts: 7.9.8
+    zowe-v2-lts: 7.10.4
     zowe-v1-lts: 6.40.10
     next: true
   # CLI plug-ins
@@ -110,7 +110,7 @@ tags:
     version: 1.28.2
     rc: 2
   zowe-v2-lts:
-    version: 2.6.1
+    version: 2.7.0
     rc: 1
   # next:
   #   version: 2.0.0


### PR DESCRIPTION
| Updated Packages | Old Version | New Version |
| --- | --- | --- |
| Imperative | 5.7.7 | 5.9.0 |
| Zowe CLI and SDKs | 7.9.7 (7.9.8 for CLI) | 7.11.0 |