### PR TITLE
Add smoke test that installs CLI and plugins

### DIFF
--- a/.github/workflows/zowe-cli-bundle.yaml
+++ b/.github/workflows/zowe-cli-bundle.yaml
@@ -178,3 +178,34 @@ jobs:
       with:
         number: ${{ steps.find-pr.outputs.pr }}
         path: summary.md
+
+  test:
+    needs: build
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest, ubuntu-latest, macos-latest]
+
+    steps:
+    - name: Use Node.js LTS
+      uses: actions/setup-node@v3
+      with:
+        node-version: 'lts/*'
+
+    - name: Download Bundle Artifact
+      uses: actions/upload-artifact@v3
+      with:
+        name: 'zowe-cli-bundle_${{ github.event.inputs.package-tag || inputs.package-tag }}'
+        path: 'zowe-cli-bundle'
+
+    - name: Install CLI
+      shell: bash
+      working-directory: zowe-cli-bundle
+      run: unzip -o zowe-cli-package-*.zip && npm install -g zowe-cli.tgz
+
+    - name: Install Plugins
+      shell: bash
+      working-directory: zowe-cli-bundle
+      run: unzip -o zowe-cli-plugins-*.zip && zowe plugins install *-for-zowe-cli.tgz

--- a/.github/workflows/zowe-cli-bundle.yaml
+++ b/.github/workflows/zowe-cli-bundle.yaml
@@ -192,10 +192,11 @@ jobs:
     - name: Use Node.js LTS
       uses: actions/setup-node@v3
       with:
+        check-latest: true
         node-version: 'lts/*'
 
     - name: Download Bundle Artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/download-artifact@v3
       with:
         name: 'zowe-cli-bundle_${{ github.event.inputs.package-tag || inputs.package-tag }}'
         path: 'zowe-cli-bundle'

--- a/.github/workflows/zowe-cli-bundle.yaml
+++ b/.github/workflows/zowe-cli-bundle.yaml
@@ -186,20 +186,21 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        node-version: [14.x, 16.x, 18.x]
         os: [windows-latest, ubuntu-latest, macos-latest]
 
     steps:
-    - name: Use Node.js LTS
-      uses: actions/setup-node@v3
-      with:
-        check-latest: true
-        node-version: 'lts/*'
-
     - name: Download Bundle Artifact
       uses: actions/download-artifact@v3
       with:
         name: 'zowe-cli-bundle_${{ github.event.inputs.package-tag || inputs.package-tag }}'
         path: 'zowe-cli-bundle'
+
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v3
+      with:
+        node-version: ${{ matrix.node-version }}
+        check-latest: true
 
     - name: Install CLI
       shell: bash
@@ -209,4 +210,4 @@ jobs:
     - name: Install Plugins
       shell: bash
       working-directory: zowe-cli-bundle
-      run: unzip -o zowe-cli-plugins-*.zip && zowe plugins install *-for-zowe-cli.tgz
+      run: unzip -o zowe-cli-plugins-*.zip && zowe plugins install *-for-zowe-cli.tgz && zowe plugins validate --fail-on-error


### PR DESCRIPTION
Adds a smoke test for the CLI and plugins to the bundle workflow which runs nightly.

Here is an example of the DB2 plugin failing on Windows + Node.js 18: https://github.com/zowe/zowe-cli-standalone-package/actions/runs/4799056189/jobs/8538278828