### PR TITLE
Allow deployment workflow to be triggered remotely

### DIFF
--- a/.github/workflows/zowe-cli-deploy-component.yaml
+++ b/.github/workflows/zowe-cli-deploy-component.yaml
@@ -34,6 +34,8 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v3
+      with:
+        repository: 'zowe/zowe-cli-standalone-package'
 
     - name: Use Node.js 16
       uses: actions/setup-node@v3

--- a/.github/workflows/zowe-cli-deploy-component.yaml
+++ b/.github/workflows/zowe-cli-deploy-component.yaml
@@ -1,6 +1,17 @@
 name: Zowe CLI Deploy Component
 
 on:
+  workflow_call:
+    inputs:
+      pkg-name:
+        required: true
+        type: string
+      pkg-tags:
+        required: true
+        type: string
+    secrets:
+      NPM_PUBLIC_TOKEN:
+        required: true
   workflow_dispatch:
     inputs:
       pkg-name:
@@ -17,8 +28,8 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      PKG_NAME: ${{ github.event.inputs.pkg-name }}
-      PKG_TAGS: ${{ github.event.inputs.pkg-tags }}
+      PKG_NAME: ${{ github.event.inputs.pkg-name || inputs.pkg-name }}
+      PKG_TAGS: ${{ github.event.inputs.pkg-tags || inputs.pkg-tags }}
 
     steps:
     - name: Checkout

--- a/scripts/deploy-component.js
+++ b/scripts/deploy-component.js
@@ -13,6 +13,7 @@ const os = require("os");
 const core = require("@actions/core");
 const exec = require("@actions/exec");
 const delay = require("delay");
+const jsYaml = require("js-yaml");
 
 const utils = require(__dirname + "/utils");
 
@@ -24,6 +25,12 @@ const VIEW_OPTS = `--${PKG_SCOPE}:registry=${SOURCE_REGISTRY}`;
 const FAILED_VERSIONS = [];
 
 async function deploy(pkgName, pkgTag) {
+    const zoweVersions = jsYaml.load(fs.readFileSync(__dirname + "/../zowe-versions.yaml", "utf-8"));
+    if (!Object.keys({ ...zoweVersions.packages, ...zoweVersions.extras }).includes(pkgName)) {
+        core.error(`❌ Cannot deploy package ${PKG_SCOPE}/${pkgName} because it is missing from zowe-versions.yaml`);
+        return;
+    }
+
     core.info(`📦 Deploying package ${PKG_SCOPE}/${pkgName}@${pkgTag}`);
     fs.rmSync(__dirname + "/../.npmrc", { force: true });
     const pkgVersion = await utils.getPackageInfo(`${PKG_SCOPE}/${pkgName}@${pkgTag}`, VIEW_OPTS);


### PR DESCRIPTION
Updated `zowe-cli-deploy-component.yml` so it can be triggered from another repo with the `workflow_call` event. This can be done securely because the repo calling the workflow must have access to an NPM publish token.

Also added documentation to the readme for how external packages can reuse our deployment automation.