### PR TITLE
Automatic version updates for zowe-versions.yaml AND manifest.json.template

### DIFF
--- a/.github/workflows/manifest_updateVersions.createPR.yml
+++ b/.github/workflows/manifest_updateVersions.createPR.yml
@@ -1,0 +1,92 @@
+name: Update Versions and Create PR
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release Version (x.x.x)'
+        required: true
+      zowe_version:
+        description: "Zowe Version Tag"
+        default: zowe-v2-lts
+        required: true
+        type: choice
+        options:
+        - zowe-v1-lts
+        - zowe-v2-lts
+
+jobs:
+  update_versions_and_create_pr:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Set Default Branch Environment Variable
+        run: |
+          if [[ "${{ github.event.inputs.zowe_version }}" == "zowe-v1-lts" ]]; then
+            echo "defaultBranch=v1.x/staging" >> $GITHUB_ENV
+          else
+            echo "defaultBranch=v2.x/staging" >> $GITHUB_ENV
+          fi
+
+      - name: Checkout zowe-install-packaging
+        uses: actions/checkout@v4
+        with:
+          repository: 'zowe/zowe-install-packaging'
+          ref: ${{ env.defaultBranch }}
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+
+      - name: Create Branch
+        run: |
+          branch_name="v${{ github.event.inputs.version }}/rc"
+          git checkout -b "$branch_name"
+
+      - name: Get and Change Component Versions
+        id: get_versions
+        run: |
+          declare -A repoAndComponent
+          repoAndComponent[imperative]=imperative
+          repoAndComponent[cli]=zowe-cli
+          repoAndComponent[cics-for-zowe-cli]=zowe-cli-cics-plugin
+          repoAndComponent[db2-for-zowe-cli]=zowe-cli-db2-plugin
+          repoAndComponent[perf-timing]=perf-timing
+          repoAndComponent[mq-for-zowe-cli]=zowe-cli-mq-plugin
+          repoAndComponent[zos-ftp-for-zowe-cli]=zowe-cli-ftp-plugin
+
+          zowe_version=${{ github.event.inputs.zowe_version }}
+
+          echo "This PR updates the following package versions in manifest.json.template for \`$zowe_version\`" >> description.txt
+          echo "| Updated Package | Old Version | New Version |" >> description.txt
+          echo "| --- | --- | --- |" >> description.txt
+          for component in "${!repoAndComponent[@]}"; do
+              repo="${repoAndComponent[$component]}"
+              current_version=$(grep -A 2 "\"repository\": \"$repo\"" manifest.json.template | awk -F '"' '/"tag":/ {print $4}')
+              new_version=v$(npm view @zowe/$component "dist-tags.$zowe_version")
+              if [[ "$new_version" != "$current_version" ]]; then
+                  echo "|$component | $current_version | $new_version|" >> description.txt
+                  # Replaces the version number. If it doesn't match on the first line after the component, it goes to the next line and checks again.
+                  sed -i -E "/\"repository\": \"$repo\"/{n;s/(\"tag\": \").*(\",)/\1$new_version\2/}" manifest.json.template
+              fi
+          done
+
+      - name: Commit and Push Changes
+        run: |
+          git config --global user.name "GitHub Actions"
+          git config --global user.email "actions@github.com"
+          git add "manifest.json.template"
+          git commit -m "Update component versions"
+          git push origin HEAD
+
+      - name: Create Pull Request
+        run: |
+          version="${{ github.event.inputs.version }}"
+          branch_name="v$version/rc"
+          pr_title="Update versions for $version"
+          body_file=description.txt
+          gh pr create --base ${{ env.defaultBranch }} --head "$branch_name" --title "$pr_title" --body-file "$body_file" --reviewer atorrise
+          echo "Pull Request created successfully"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/manifest_updateVersions.createPR.yml
+++ b/.github/workflows/manifest_updateVersions.createPR.yml
@@ -23,9 +23,9 @@ jobs:
       - name: Set Default Branch Environment Variable
         run: |
           if [[ "${{ github.event.inputs.zowe_version }}" == "zowe-v1-lts" ]]; then
-            echo "defaultBranch=v1.x/staging" >> $GITHUB_ENV
+            echo "defaultBranch=v1.x/rc" >> $GITHUB_ENV
           else
-            echo "defaultBranch=v2.x/staging" >> $GITHUB_ENV
+            echo "defaultBranch=v2.x/rc" >> $GITHUB_ENV
           fi
 
       - name: Checkout zowe-install-packaging
@@ -41,7 +41,7 @@ jobs:
 
       - name: Create Branch
         run: |
-          branch_name="v${{ github.event.inputs.version }}/rc"
+          branch_name="v${{ github.event.inputs.version }}/cli/rc"
           git checkout -b "$branch_name"
 
       - name: Get and Change Component Versions
@@ -87,7 +87,7 @@ jobs:
       - name: Create Pull Request
         run: |
           version="${{ github.event.inputs.version }}"
-          branch_name="v$version/rc"
+          branch_name="v$version/cli/rc"
           pr_title="Update versions for $version"
           body_file=description.txt
           gh pr create --base ${{ env.defaultBranch }} --head "$branch_name" --title "$pr_title" --body-file "$body_file" --reviewer atorrise

--- a/.github/workflows/manifest_updateVersions.createPR.yml
+++ b/.github/workflows/manifest_updateVersions.createPR.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: lts/*
 
       - name: Create Branch
         run: |

--- a/.github/workflows/manifest_updateVersions.createPR.yml
+++ b/.github/workflows/manifest_updateVersions.createPR.yml
@@ -58,6 +58,10 @@ jobs:
 
           zowe_version=${{ github.event.inputs.zowe_version }}
 
+          if [[ "$zowe_version" == "zowe-v1-lts" ]]; then
+            repoAndComponent[secure-credential-store-for-zowe-cli]=zowe-cli-scs-plugin
+          fi
+
           echo "This PR updates the following package versions in manifest.json.template for \`$zowe_version\`" >> description.txt
           echo "| Updated Package | Old Version | New Version |" >> description.txt
           echo "| --- | --- | --- |" >> description.txt

--- a/.github/workflows/manifest_updateVersions.createPR.yml
+++ b/.github/workflows/manifest_updateVersions.createPR.yml
@@ -1,4 +1,4 @@
-name: Update Versions and Create PR
+name: Update Versions and Create PR (manifest)
 
 on:
   workflow_dispatch:

--- a/.github/workflows/updateVersionsAndCreatePR.yml
+++ b/.github/workflows/updateVersionsAndCreatePR.yml
@@ -1,0 +1,81 @@
+name: Update Versions and Create PR
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release version'
+        required: true
+      zowe_version:
+        description: 'Zowe version ("zowe-v1-lts" or "zowe-v2-lts")'
+        required: true
+
+jobs:
+  update_versions_and_create_pr:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: 14
+
+      - name: Install Dependencies
+        run: |
+          sudo apt-get update -y
+          sudo apt install gh
+
+      - name: Check gh version
+        run: gh --version
+
+      - name: Create Branch
+        run: |
+          version_name="${{ github.event.inputs.version }}"
+          branch_name="update-versions-${version_name}"
+          git checkout -b "$branch_name"
+
+      - name: Get and Change Component Versions
+        id: get_versions
+        run: |
+          components=("perf-timing" "imperative" "cli-test-utils" "secrets-for-zowe-sdk" "core-for-zowe-sdk" "zos-uss-for-zowe-sdk" "provisioning-for-zowe-sdk" "zos-console-for-zowe-sdk" "zos-files-for-zowe-sdk" "zos-logs-for-zowe-sdk" "zosmf-for-zowe-sdk" "zos-workflows-for-zowe-sdk" "zos-jobs-for-zowe-sdk" "zos-tso-for-zowe-sdk" "cli" "cics-for-zowe-cli" "db2-for-zowe-cli" "ims-for-zowe-cli" "mq-for-zowe-cli" "secure-credential-store-for-zowe-cli" "zos-ftp-for-zowe-cli")
+          zowe_version="${{ github.event.inputs.zowe_version }}"
+          version="${{ github.event.inputs.version }}"
+          echo "This PR updates the following package versions in zowe-versions.yaml for \`$zowe_version\`" >> description.txt
+          echo "| Updated Package | Old Version | New Version |" >> description.txt
+          echo "| --- | --- | --- |" >> description.txt
+          for component in "${components[@]}"; do
+            current_version=$(grep -A 2 "^  $component:" zowe-versions.yaml | grep "$zowe_version" | awk '{print $2}')
+            new_version=$(npm view @zowe/$component "dist-tags.$zowe_version")
+            if [[ "$new_version" != "$current_version" ]]; then
+              echo "|$component | $current_version | $new_version|" >> description.txt
+              sed -i -E "/^  $component:/ { n; s/($zowe_version: ).*/\1$new_version/; t; n; s/($zowe_version: ).*/\1$new_version/ }" zowe-versions.yaml
+            fi
+          done
+
+          # Update zowe-versions.yaml tags section
+          sed -i -E "/$zowe_version:/ { n; s/(version: ).*/\1$version/ }" zowe-versions.yaml
+
+
+      - name: Commit and Push Changes
+        run: |
+          git config --global user.name "GitHub Actions"
+          git config --global user.email "actions@github.com"
+          git commit -am "Update component versions"
+          git push origin HEAD
+
+      - name: Create Pull Request
+        run: |
+          version_name="${{ github.event.inputs.version }}"
+          branch_name="update-versions-${version_name}"
+          pr_title="Update versions for $version_name"
+          body_file=description.txt
+          gh pr create --base master --head "$branch_name" --title "$pr_title" --body-file "$body_file" --reviewer atorrise
+          echo "Pull Request created successfully"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Delete description.txt
+        run: rm description.txt

--- a/.github/workflows/zowe-versions_updateVersions_createPR.yml
+++ b/.github/workflows/zowe-versions_updateVersions_createPR.yml
@@ -38,16 +38,13 @@ jobs:
         id: get_versions
         run: |
           zowe_version="${{ github.event.inputs.zowe_version }}"
-          components=$(yq '.packages | with_entries(select(.value."$zowe_version")) | keys | .[]' zowe-versions.yaml)
+          components=$(yq -r ".packages | with_entries(select(.value.\"$zowe_version\")) | keys | .[]" zowe-versions.yaml)
           version="${{ github.event.inputs.version }}"
-          if [[ "$zowe_version" == "zowe-v1-lts" ]]; then
-            components+=("secure-credential-store-for-zowe-cli")
-          fi
           # echoing to txt file to later add this file as the PR description
           echo "This PR updates the following package versions in zowe-versions.yaml for \`$zowe_version\`" >> description.txt
           echo "| Updated Package | Old Version | New Version |" >> description.txt
           echo "| --- | --- | --- |" >> description.txt
-          for component in "${components[@]}"; do
+          for component in $components"; do
             current_version=$(grep -A 2 "^  $component:" zowe-versions.yaml | grep "$zowe_version" | awk '{print $2}')
             new_version=$(npm view @zowe/$component "dist-tags.$zowe_version")
             if [[ "$new_version" != "$current_version" ]]; then
@@ -57,8 +54,8 @@ jobs:
             fi
           done
 
-          # Update zowe-versions.yaml tags section
-          sed -i -E "/$zowe_version:/ { n; s/(version: ).*/\1$version/ }" zowe-versions.yaml
+          # Update zowe-versions.yaml tags section (always sets rc = 1)
+          sed -i -E "/$zowe_version:/ { n; s/(version: ).*/\1$version/; s/(rc: )[0-9]+/\11/ }" zowe-versions.yaml
 
 
       - name: Commit and Push Changes

--- a/.github/workflows/zowe-versions_updateVersions_createPR.yml
+++ b/.github/workflows/zowe-versions_updateVersions_createPR.yml
@@ -4,11 +4,16 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Release version'
+        description: 'Release Version (x.x.x)'
         required: true
       zowe_version:
-        description: 'Zowe version ("zowe-v1-lts" or "zowe-v2-lts")'
+        description: "Zowe Version Tag"
+        default: zowe-v2-lts
         required: true
+        type: choice
+        options:
+        - zowe-v1-lts
+        - zowe-v2-lts
 
 jobs:
   update_versions_and_create_pr:
@@ -16,20 +21,12 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
-          node-version: 14
-
-      - name: Install Dependencies
-        run: |
-          sudo apt-get update -y
-          sudo apt install gh
-
-      - name: Check gh version
-        run: gh --version
+          node-version: lts/*
 
       - name: Create Branch
         run: |
@@ -40,9 +37,13 @@ jobs:
       - name: Get and Change Component Versions
         id: get_versions
         run: |
-          components=("perf-timing" "imperative" "cli-test-utils" "secrets-for-zowe-sdk" "core-for-zowe-sdk" "zos-uss-for-zowe-sdk" "provisioning-for-zowe-sdk" "zos-console-for-zowe-sdk" "zos-files-for-zowe-sdk" "zos-logs-for-zowe-sdk" "zosmf-for-zowe-sdk" "zos-workflows-for-zowe-sdk" "zos-jobs-for-zowe-sdk" "zos-tso-for-zowe-sdk" "cli" "cics-for-zowe-cli" "db2-for-zowe-cli" "ims-for-zowe-cli" "mq-for-zowe-cli" "secure-credential-store-for-zowe-cli" "zos-ftp-for-zowe-cli")
+          components=("perf-timing" "imperative" "cli-test-utils" "secrets-for-zowe-sdk" "core-for-zowe-sdk" "zos-uss-for-zowe-sdk" "provisioning-for-zowe-sdk" "zos-console-for-zowe-sdk" "zos-files-for-zowe-sdk" "zos-logs-for-zowe-sdk" "zosmf-for-zowe-sdk" "zos-workflows-for-zowe-sdk" "zos-jobs-for-zowe-sdk" "zos-tso-for-zowe-sdk" "cli" "cics-for-zowe-cli" "db2-for-zowe-cli" "ims-for-zowe-cli" "mq-for-zowe-cli" "zos-ftp-for-zowe-cli")
           zowe_version="${{ github.event.inputs.zowe_version }}"
           version="${{ github.event.inputs.version }}"
+          if [[ "$zowe_version" == "zowe-v1-lts" ]]; then
+            components+=("secure-credential-store-for-zowe-cli")
+          fi
+          # echoing to txt file to later add this file as the PR description
           echo "This PR updates the following package versions in zowe-versions.yaml for \`$zowe_version\`" >> description.txt
           echo "| Updated Package | Old Version | New Version |" >> description.txt
           echo "| --- | --- | --- |" >> description.txt
@@ -51,6 +52,7 @@ jobs:
             new_version=$(npm view @zowe/$component "dist-tags.$zowe_version")
             if [[ "$new_version" != "$current_version" ]]; then
               echo "|$component | $current_version | $new_version|" >> description.txt
+              # Replaces the version number. If it doesn't match on the first line after the component, it goes to the next line and checks again.
               sed -i -E "/^  $component:/ { n; s/($zowe_version: ).*/\1$new_version/; t; n; s/($zowe_version: ).*/\1$new_version/ }" zowe-versions.yaml
             fi
           done
@@ -67,15 +69,17 @@ jobs:
           git push origin HEAD
 
       - name: Create Pull Request
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           version_name="${{ github.event.inputs.version }}"
           branch_name="update-versions-${version_name}"
-          pr_title="Update versions for $version_name"
+          pr_title="Update zowe component versions for $version_name"
           body_file=description.txt
-          gh pr create --base master --head "$branch_name" --title "$pr_title" --body-file "$body_file" --reviewer atorrise
+          gh pr create --base master --head "$branch_name" --title "$pr_title" --body-file "$body_file"
+          gh pr edit --add-reviewer awharn
+          gh pr edit --add-reviewer atorrise
+          gh pr edit --add-reviewer t1m0thyj
+          gh pr edit --add-reviewer traeok
+          gh pr edit --add-reviewer zFernand0
           echo "Pull Request created successfully"
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Delete description.txt
-        run: rm description.txt

--- a/.github/workflows/zowe-versions_updateVersions_createPR.yml
+++ b/.github/workflows/zowe-versions_updateVersions_createPR.yml
@@ -1,4 +1,4 @@
-name: Update Versions and Create PR
+name: Update Versions and Create PR (zowe-versions)
 
 on:
   workflow_dispatch:
@@ -37,8 +37,8 @@ jobs:
       - name: Get and Change Component Versions
         id: get_versions
         run: |
-          components=("perf-timing" "imperative" "cli-test-utils" "secrets-for-zowe-sdk" "core-for-zowe-sdk" "zos-uss-for-zowe-sdk" "provisioning-for-zowe-sdk" "zos-console-for-zowe-sdk" "zos-files-for-zowe-sdk" "zos-logs-for-zowe-sdk" "zosmf-for-zowe-sdk" "zos-workflows-for-zowe-sdk" "zos-jobs-for-zowe-sdk" "zos-tso-for-zowe-sdk" "cli" "cics-for-zowe-cli" "db2-for-zowe-cli" "ims-for-zowe-cli" "mq-for-zowe-cli" "zos-ftp-for-zowe-cli")
           zowe_version="${{ github.event.inputs.zowe_version }}"
+          components=$(yq '.packages | with_entries(select(.value."$zowe_version")) | keys | .[]' zowe-versions.yaml)
           version="${{ github.event.inputs.version }}"
           if [[ "$zowe_version" == "zowe-v1-lts" ]]; then
             components+=("secure-credential-store-for-zowe-cli")

--- a/.github/workflows/zowe-versions_updateVersions_createPR.yml
+++ b/.github/workflows/zowe-versions_updateVersions_createPR.yml
@@ -44,7 +44,7 @@ jobs:
           echo "This PR updates the following package versions in zowe-versions.yaml for \`$zowe_version\`" >> description.txt
           echo "| Updated Package | Old Version | New Version |" >> description.txt
           echo "| --- | --- | --- |" >> description.txt
-          for component in $components"; do
+          for component in $components; do
             current_version=$(grep -A 2 "^  $component:" zowe-versions.yaml | grep "$zowe_version" | awk '{print $2}')
             new_version=$(npm view @zowe/$component "dist-tags.$zowe_version")
             if [[ "$new_version" != "$current_version" ]]; then


### PR DESCRIPTION
**What It Does**
This PR contains 2 workflows:
1)  One that takes two inputs and uses them to automatically update zowe-scoped packages within `zowe-versions.yaml`, greatly simplifying the once arduous start to the team's release process.
2) Another that takes the same input and uses them to update the same packages but in a different repo, 
`zowe-install-packaging`, and file `manifest.json.template`

![image](https://github.com/zowe/zowe-cli-standalone-package/assets/112635587/f23e4241-67fa-44e5-b313-d4c1023d19d0)
<br>
 `zowe-versions_updateVersions_createPR.yml`: 
- Creates a new branch from master
- Gets and keeps track of changed component versions that match the input zowe-version tag
- Amends the `zowe-versions.yaml` file to reflect any updates
- Commits changes and creates a pull request with a table in its description that denotes all of the updated versions
- Assigns CLI squad to review the newly created PR

 `manifest_updateVersions_createPR.yml`:
- Checks out 'zowe/zowe-install-packaging'
- Creates a new branch from `env.defaultBranch`
- Gets and keeps track of changed component versions that match the input zowe-version tag
- Amends the `manifest.json.template` file to reflect any updates
- Commits changes and creates a pull request with a table in its description that denotes all of the updated versions
- Assigns OJ as reviewer for the newly created PR

**How to Test**
 [privately forked repo](https://github.com/ATorrise/gha) contains the same workflows here for your testing purposes. Run the workflow on the master branch to view how the github action changes the details of the `zowe-versions.yaml` and creates a PR with these changes.

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [ ] added/updated automated tests
- [ ] updated the changelog
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)

> **Note**
>I needed to create a secret with the following permissions in order to trigger this workflow and use gh cli commands like create the PR and add reviewers. The secret we use for zowe robot might need to be modified or we will have to create a new secret, a topic for discussion.
>![image](https://github.com/zowe/zowe-cli-standalone-package/assets/112635587/3b605eb8-f582-4a3b-83e1-80f2f965483d)
