### PR TITLE
Fix missing permission on Bundle All workflow

### DIFF
--- a/.github/workflows/zowe-cli-bundle-all.yaml
+++ b/.github/workflows/zowe-cli-bundle-all.yaml
@@ -12,6 +12,8 @@ jobs:
   build-v1-lts:
     if: ${{ github.event_name != 'pull_request' || !startsWith(github.head_ref, 'v2') }}
     uses: ./.github/workflows/zowe-cli-bundle.yaml
+    permissions:
+      pull-requests: write
     secrets:
       JF_ARTIFACTORY_TOKEN: ${{ secrets.JF_ARTIFACTORY_TOKEN }}
     with:
@@ -22,6 +24,8 @@ jobs:
   build-v2-lts:
     if: ${{ github.event_name != 'pull_request' || !startsWith(github.head_ref, 'v1') }}
     uses: ./.github/workflows/zowe-cli-bundle.yaml
+    permissions:
+      pull-requests: write
     secrets:
       JF_ARTIFACTORY_TOKEN: ${{ secrets.JF_ARTIFACTORY_TOKEN }}
     with:
@@ -31,6 +35,8 @@ jobs:
 
   # build-next:
   #   uses: ./.github/workflows/zowe-cli-bundle.yaml
+  #   permissions:
+  #     pull-requests: write
   #   secrets:
   #     JF_ARTIFACTORY_TOKEN: ${{ secrets.JF_ARTIFACTORY_TOKEN }}
   #   with:


### PR DESCRIPTION
**What It Does**
<!-- A list of relevant issues, enhancements, fixed bugs, etc -->
Fixes error on https://github.com/zowe/zowe-cli-standalone-package/actions/runs/10821649531:
`The nested job 'build' is requesting 'pull-requests: write', but is only allowed 'pull-requests: none'.`

**How to Test**
<!-- If a bug has been fixed, how can reviewers verify that the change(s) fixed it? -->

**Review Checklist**
I certify that I have:
- [ ] tested my changes
- [ ] added/updated automated tests
- [ ] updated the changelog
- [ ] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->