### PR TITLE
Fix missing permission on Bundle All workflow

### DIFF
--- a/.github/workflows/zowe-cli-bundle-all.yaml
+++ b/.github/workflows/zowe-cli-bundle-all.yaml
@@ -13,6 +13,7 @@ jobs:
     if: ${{ github.event_name != 'pull_request' || startsWith(github.head_ref, 'v1') }}
     uses: ./.github/workflows/zowe-cli-bundle.yaml
     permissions:
+      id-token: write
       pull-requests: write
     secrets:
       JF_ARTIFACTORY_TOKEN: ${{ secrets.JF_ARTIFACTORY_TOKEN }}
@@ -25,6 +26,7 @@ jobs:
     if: ${{ github.event_name != 'pull_request' || startsWith(github.head_ref, 'v2') }}
     uses: ./.github/workflows/zowe-cli-bundle.yaml
     permissions:
+      id-token: write
       pull-requests: write
     secrets:
       JF_ARTIFACTORY_TOKEN: ${{ secrets.JF_ARTIFACTORY_TOKEN }}
@@ -37,6 +39,7 @@ jobs:
     if: ${{ github.event_name != 'pull_request' || startsWith(github.head_ref, 'v3') }}
     uses: ./.github/workflows/zowe-cli-bundle.yaml
     permissions:
+      id-token: write
       pull-requests: write
     secrets:
       JF_ARTIFACTORY_TOKEN: ${{ secrets.JF_ARTIFACTORY_TOKEN }}
@@ -48,6 +51,7 @@ jobs:
   # build-next:
   #   uses: ./.github/workflows/zowe-cli-bundle.yaml
   #   permissions:
+  #     id-token: write
   #     pull-requests: write
   #   secrets:
   #     JF_ARTIFACTORY_TOKEN: ${{ secrets.JF_ARTIFACTORY_TOKEN }}


### PR DESCRIPTION
**What It Does**
<!-- A list of relevant issues, enhancements, fixed bugs, etc -->
Fixes error on https://github.com/zowe/zowe-cli-standalone-package/actions/runs/11171654914:
`The nested job 'build' is requesting 'id-token: write', but is only allowed 'id-token: none'.`

**How to Test**
<!-- If a bug has been fixed, how can reviewers verify that the change(s) fixed it? -->

**Review Checklist**
I certify that I have:
- [ ] tested my changes
- [ ] added/updated automated tests
- [ ] updated the changelog
- [ ] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->