### PR TITLE
Follow redirects when downloading packages from Artifactory

### DIFF
--- a/scripts/deploy-component.js
+++ b/scripts/deploy-component.js
@@ -61,7 +61,7 @@ async function deploy(pkgName, pkgTag) {
     } catch (err) {
         const tgzUrl = await utils.getPackageInfo(`${PKG_SCOPE}/${pkgName}@${pkgTag}`, VIEW_OPTS, "dist.tarball");
         const fullPkgName = `${pkgName}-${pkgVersion}.tgz`;
-        await utils.execAndGetStderr("curl", ["-fs", "-o", fullPkgName, tgzUrl]);
+        await utils.execAndGetStderr("curl", ["-fsL", "-o", fullPkgName, tgzUrl]);
         await utils.execAndGetStderr("bash", ["scripts/repackage_tar.sh", fullPkgName, TARGET_REGISTRY, pkgVersion]);
         pkgTag = pkgTag !== pkgVersion ? pkgTag : TEMP_NPM_TAG;
         await utils.execAndGetStderr("npm", ["publish", fullPkgName, "--access", "public", "--tag", pkgTag]);


### PR DESCRIPTION
**What It Does**
Not sure why Artifactory started redirecting for the CLI package TGZ, but this PR should fix the failing nightly deployment:
https://github.com/zowe/zowe-cli-standalone-package/actions/runs/11357732730/job/31615012381

**How to Test**
Run cURL and notice it downloads an empty file, then add the `-L` flag and it works:
```
curl -fs -o cli-8.3.0.tgz https://zowe.jfrog.io/zowe/api/npm/npm-local-release/@zowe/cli/-/@zowe/cli-8.3.0.tgz
curl -fsL -o cli-8.3.0.tgz https://zowe.jfrog.io/zowe/api/npm/npm-local-release/@zowe/cli/-/@zowe/cli-8.3.0.tgz
```