### PR TITLE
Fix error bundling wheels for Python Secrets SDK

### DIFF
--- a/.github/workflows/zowe-cli-bundle.yaml
+++ b/.github/workflows/zowe-cli-bundle.yaml
@@ -146,7 +146,7 @@ jobs:
           pip3 download --no-binary charset-normalizer,pyrsistent,pyyaml --pre zowe-python-sdk-bundle
           # Download Secrets SDK binary wheels for all platforms
           curl -fs https://pypi.org/project/zowe-secrets-for-zowe-sdk/#files |
-            grep -Eo 'href="[^"]+\.whl"' | cut -d '"' -f 2 |
+            grep -Eo 'href="https://[^"]+\.whl"' | cut -d '"' -f 2 |
             while read -r url; do curl -fLOJ $url; done
         else
           pip3 download --no-binary charset-normalizer,pyyaml zowe


### PR DESCRIPTION
**What It Does**
<!-- A list of relevant issues, enhancements, fixed bugs, etc -->
Fixes an error in the nightly bundle workflow: `curl: (3) URL using bad/illegal format or missing URL`
https://github.com/zowe/zowe-cli-standalone-package/actions/runs/11828092184/job/32957527889

**How to Test**
<!-- If a bug has been fixed, how can reviewers verify that the change(s) fixed it? -->
Run the updated cURL command locally - it should print a list of only valid URLs:
```bash
curl -fs https://pypi.org/project/zowe-secrets-for-zowe-sdk/#files |
  grep -Eo 'href="https://[^"]+\.whl"' | cut -d '"' -f 2 |
```

**Review Checklist**
I certify that I have:
- [ ] tested my changes
- [ ] added/updated automated tests
- [ ] updated the changelog
- [ ] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->