### PR TITLE
Fix CLI package pointing to Zowe Artifactory

### DIFF
--- a/scripts/repackage_tar.sh
+++ b/scripts/repackage_tar.sh
@@ -9,6 +9,7 @@
 # Copyright Contributors to the Zowe Project.
 #
 ###
+set -e
 
 die () {
     echo "$@"

--- a/scripts/repackage_tar.sh
+++ b/scripts/repackage_tar.sh
@@ -47,7 +47,7 @@ npmDeps=`node -e "package = require('./package.json');
     Object.entries(package.peerDependencies || {}).forEach(([name, version]) => console.log(name + '@' + version));"`
 for pkgSpec in $npmDeps; do
     echo "Validating dependency $pkgSpec..."
-    npm view $pkgSpec || exit 1
+    npm view $pkgSpec || die "Validation of $pkgSpec failed"
 done
 
 # Update npm-shrinkwrap.json if necessary
@@ -57,6 +57,7 @@ if [ -e "npm-shrinkwrap.json" ]; then
 
     # Rewrite the shrinkwrap file with only production dependencies and public npm resolved URLs
     node "../../scripts/rewrite-shrinkwrap.js"
+    (! grep -q zowe.jfrog.io npm-shrinkwrap.json) || die "Private registry found in shrinkwrap file"
 fi
 
 npm pack

--- a/scripts/rewrite-shrinkwrap.js
+++ b/scripts/rewrite-shrinkwrap.js
@@ -17,7 +17,7 @@ const data = require(_path);
 (async () => {
   const filterPkgs = async (obj, key) => {
     const _obj = {};
-    for (const pkg of Object.keys(obj[key])) {
+    for (const pkg of Object.keys(obj[key] || {})) {
       if (obj[key][pkg].dev) continue;
       if (obj[key][pkg].peer) continue;
       if (obj[key][pkg].extraneous) continue;


### PR DESCRIPTION
**What It Does**
<!-- A list of relevant issues, enhancements, fixed bugs, etc -->
Fixes an issue where `npm-shrinkwrap.json` file in CLI package on npmjs.org references Zowe Artifactory (zowe.jfrog.io).

**How to Test**
<!-- If a bug has been fixed, how can reviewers verify that the change(s) fixed it? -->
Run the repackage tar script locally and check the npm-shrinkwrap.json file in the resulting TGZ:
```
curl -fsL -o cli-8.8.3.tgz https://zowe.jfrog.io/zowe/api/npm/npm-local-release/@zowe/cli/-/@zowe/cli-8.8.3.tgz
bash scripts/repackage_tar.sh cli-8.8.3.tgz https://registry.npmjs.org/ 8.8.3
```

**Review Checklist**
I certify that I have:
- [ ] tested my changes
- [ ] added/updated automated tests
- [ ] updated the changelog
- [ ] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->