### PR TITLE
Remove zowe-v1-lts from workflows

### DIFF
--- a/.github/workflows/manifest_updateVersions.createPR.yml
+++ b/.github/workflows/manifest_updateVersions.createPR.yml
@@ -12,7 +12,6 @@ on:
         required: true
         type: choice
         options:
-        - zowe-v1-lts
         - zowe-v2-lts
         - zowe-v3-lts
 
@@ -27,9 +26,7 @@ jobs:
     steps:
       - name: Set Default Branch Environment Variable
         run: |
-          if [[ "${{ github.event.inputs.zowe_version }}" == "zowe-v1-lts" ]]; then
-            echo "defaultBranch=v1.x/rc" >> $GITHUB_ENV
-          elif [[ "${{ github.event.inputs.zowe_version }}" == "zowe-v2-lts" ]]; then
+          if [[ "${{ github.event.inputs.zowe_version }}" == "zowe-v2-lts" ]]; then
             echo "defaultBranch=v2.x/rc" >> $GITHUB_ENV
           else
             echo "defaultBranch=v3.x/rc" >> $GITHUB_ENV
@@ -66,9 +63,6 @@ jobs:
 
           if [[ "$zowe_version" =~ ^zowe-v[12]-lts$ ]]; then
             repoAndComponent[ims-for-zowe-cli]=zowe-cli-ims-plugin
-          fi
-          if [[ "$zowe_version" == "zowe-v1-lts" ]]; then
-            repoAndComponent[secure-credential-store-for-zowe-cli]=zowe-cli-scs-plugin
           fi
 
           echo "This PR updates the following package versions in manifest.json.template for \`$zowe_version\`" >> description.txt

--- a/.github/workflows/zowe-cli-bundle-all.yaml
+++ b/.github/workflows/zowe-cli-bundle-all.yaml
@@ -9,19 +9,6 @@ on:
   - cron: '0 0 * * *'
 
 jobs:
-  build-v1-lts:
-    if: ${{ github.event_name != 'pull_request' || startsWith(github.head_ref, 'v1') }}
-    uses: ./.github/workflows/zowe-cli-bundle.yaml
-    permissions:
-      id-token: write
-      pull-requests: write
-    secrets:
-      JF_ARTIFACTORY_TOKEN: ${{ secrets.JF_ARTIFACTORY_TOKEN }}
-    with:
-      dry-run: ${{ github.event_name != 'schedule' }}
-      package-tag: zowe-v1-lts
-      release-type: snapshot
-
   build-v2-lts:
     if: ${{ github.event_name != 'pull_request' || startsWith(github.head_ref, 'v2') }}
     uses: ./.github/workflows/zowe-cli-bundle.yaml

--- a/.github/workflows/zowe-cli-bundle.yaml
+++ b/.github/workflows/zowe-cli-bundle.yaml
@@ -138,7 +138,11 @@ jobs:
       run: |
         mkdir -p temp && cd temp
         mkdir -p licenses && cd licenses && cp /tmp/zowe_licenses_cli.zip zowe_licenses_cli.zip && cd ..
-        pip3 download --no-binary charset-normalizer,pyyaml zowe
+        pip3 download --no-binary charset-normalizer,pyrsistent,pyyaml --pre zowe-python-sdk-bundle
+        # Download Secrets SDK binary wheels for all platforms
+        curl -fs https://pypi.org/project/zowe-secrets-for-zowe-sdk/#files |
+          grep -Eo 'href="https://[^"]+\.whl"' | cut -d '"' -f 2 |
+          while read -r url; do curl -fLOJ $url; done
         TZ=UTC find . -exec touch -t 197001010000.00 {} +
         TZ=UTC zip -roX zowe-sdk.zip *
         mv zowe-sdk.zip ../zowe-python-sdk-${{ env.BUNDLE_VERSION }}.zip

--- a/.github/workflows/zowe-cli-bundle.yaml
+++ b/.github/workflows/zowe-cli-bundle.yaml
@@ -23,7 +23,6 @@ on:
         required: true
         type: choice
         options:
-        - zowe-v1-lts
         - zowe-v2-lts
         - zowe-v3-lts
         # - next
@@ -94,9 +93,6 @@ jobs:
         mkdir -p temp && cd temp
         mkdir -p licenses && cd licenses && cp /tmp/zowe_licenses_cli.zip zowe_licenses_cli.zip && cd ..
         npm pack @zowe/cli@${{ steps.versions.outputs.packages_cli }}
-        if [[ "${{ inputs.package-tag }}" == "zowe-v1-lts" ]]; then
-          npm pack @zowe/secure-credential-store-for-zowe-cli@${{ steps.versions.outputs.packages_secure-credential-store-for-zowe-cli }}
-        fi
         bash ../scripts/repackage_bundle.sh *.tgz
         mv zowe-cli-package.zip ../zowe-cli-package-${{ env.BUNDLE_VERSION }}.zip
         rm -rf *
@@ -142,15 +138,7 @@ jobs:
       run: |
         mkdir -p temp && cd temp
         mkdir -p licenses && cd licenses && cp /tmp/zowe_licenses_cli.zip zowe_licenses_cli.zip && cd ..
-        if [[ "${{ inputs.package-tag }}" != "zowe-v1-lts" ]]; then
-          pip3 download --no-binary charset-normalizer,pyrsistent,pyyaml --pre zowe-python-sdk-bundle
-          # Download Secrets SDK binary wheels for all platforms
-          curl -fs https://pypi.org/project/zowe-secrets-for-zowe-sdk/#files |
-            grep -Eo 'href="https://[^"]+\.whl"' | cut -d '"' -f 2 |
-            while read -r url; do curl -fLOJ $url; done
-        else
-          pip3 download --no-binary charset-normalizer,pyyaml zowe
-        fi
+        pip3 download --no-binary charset-normalizer,pyyaml zowe
         TZ=UTC find . -exec touch -t 197001010000.00 {} +
         TZ=UTC zip -roX zowe-sdk.zip *
         mv zowe-sdk.zip ../zowe-python-sdk-${{ env.BUNDLE_VERSION }}.zip

--- a/.github/workflows/zowe-versions_updateVersions_createPR.yml
+++ b/.github/workflows/zowe-versions_updateVersions_createPR.yml
@@ -12,7 +12,6 @@ on:
         required: true
         type: choice
         options:
-        - zowe-v1-lts
         - zowe-v2-lts
         - zowe-v3-lts
 

--- a/zowe-versions.yaml
+++ b/zowe-versions.yaml
@@ -13,11 +13,9 @@ packages:
   # Core CLI and SDKs
   perf-timing:
     next: false
-    zowe-v1-lts: 1.0.7
     zowe-v2-lts: 1.0.7
   imperative:
     next: true
-    zowe-v1-lts: 4.18.27
     zowe-v2-lts: 5.27.0
     zowe-v3-lts: 8.11.0
   cli-test-utils:
@@ -30,90 +28,70 @@ packages:
     zowe-v3-lts: 8.10.4
   core-for-zowe-sdk:
     next: true
-    zowe-v1-lts: 6.40.31
     zowe-v2-lts: 7.29.0
     zowe-v3-lts: 8.11.0
   zos-uss-for-zowe-sdk:
     next: true
-    zowe-v1-lts: 6.40.31
     zowe-v2-lts: 7.29.0
     zowe-v3-lts: 8.11.0
   provisioning-for-zowe-sdk:
     next: true
-    zowe-v1-lts: 6.40.31
     zowe-v2-lts: 7.29.0
     zowe-v3-lts: 8.11.0
   zos-console-for-zowe-sdk:
     next: true
-    zowe-v1-lts: 6.40.31
     zowe-v2-lts: 7.29.0
     zowe-v3-lts: 8.11.0
   zos-files-for-zowe-sdk:
     next: true
-    zowe-v1-lts: 6.40.31
     zowe-v2-lts: 7.29.0
     zowe-v3-lts: 8.11.0
   zos-logs-for-zowe-sdk:
     next: true
-    zowe-v1-lts: 6.40.31
     zowe-v2-lts: 7.29.0
     zowe-v3-lts: 8.11.0
   zosmf-for-zowe-sdk:
     next: true
-    zowe-v1-lts: 6.40.31
     zowe-v2-lts: 7.29.0
     zowe-v3-lts: 8.11.0
   zos-workflows-for-zowe-sdk:
     next: true
-    zowe-v1-lts: 6.40.31
     zowe-v2-lts: 7.29.0
     zowe-v3-lts: 8.11.0
   zos-jobs-for-zowe-sdk:
     next: true
-    zowe-v1-lts: 6.40.31
     zowe-v2-lts: 7.29.0
     zowe-v3-lts: 8.11.0
   zos-tso-for-zowe-sdk:
     next: true
-    zowe-v1-lts: 6.40.31
     zowe-v2-lts: 7.29.0
     zowe-v3-lts: 8.11.0
   cli:
     next: true
-    zowe-v1-lts: 6.40.32
     zowe-v2-lts: 7.29.1
     zowe-v3-lts: 8.11.0
   # CLI plug-ins
   cics-for-zowe-sdk:
     next: true
-    zowe-v1-lts: 4.0.11
     zowe-v2-lts: 5.0.6
     zowe-v3-lts: 6.2.4
   cics-for-zowe-cli:
     next: true
-    zowe-v1-lts: 4.0.11
     zowe-v2-lts: 5.0.6
     zowe-v3-lts: 6.2.4
   db2-for-zowe-cli:
     next: true
-    zowe-v1-lts: 4.1.15
     zowe-v2-lts: 5.0.9
     zowe-v3-lts: 6.1.0
   ims-for-zowe-cli:
     next: true
-    zowe-v1-lts: 2.0.5
     zowe-v2-lts: 3.0.1
   mq-for-zowe-cli:
     next: true
-    zowe-v1-lts: 2.0.4
     zowe-v2-lts: 3.0.1
     zowe-v3-lts: 4.0.0
-  secure-credential-store-for-zowe-cli:
-    next: false
-    zowe-v1-lts: 4.1.12
   zos-ftp-for-zowe-cli:
     next: true
-    zowe-v1-lts: 1.8.8
     zowe-v2-lts: 2.1.9
     zowe-v3-lts: 3.0.0
 # Define extra @zowe-scoped packages that are not included in the Zowe bundle.
@@ -130,9 +108,6 @@ extras:
     next: true
 # Define version info for the latest staged Zowe release.
 tags:
-  zowe-v1-lts:
-    version: 1.28.8
-    rc: 2
   zowe-v2-lts:
     version: 2.18.0
     rc: 6


### PR DESCRIPTION
**What It Does**
<!-- A list of relevant issues, enhancements, fixed bugs, etc -->
Fixes the nightly workflow failing because V1 LTS DB2 plug-in is not compatible with Node 22 on Windows:
https://github.com/zowe/zowe-cli-standalone-package/actions/runs/12758377455/job/35593670663

**How to Test**
<!-- If a bug has been fixed, how can reviewers verify that the change(s) fixed it? -->

**Review Checklist**
I certify that I have:
- [ ] tested my changes
- [ ] added/updated automated tests
- [ ] updated the changelog
- [ ] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->