### PR TITLE
Disable publishing next tag for cics api package

### DIFF
--- a/scripts/smoke-test-components.js
+++ b/scripts/smoke-test-components.js
@@ -11,9 +11,14 @@ const errors = [];
 
 async function test(pkgName, pkgTag) {
     core.info(`Verifying that package ${pkgName} with tag ${pkgTag} can be installed`);
+    const installArgs = [];
+    if (pkgName.includes("zowe-explorer-api")) {
+        // Override @zowe:registry for ZE API package since it isn't published to Artifactory
+        installArgs.push("--@zowe:registry=https://registry.npmjs.org/");
+    }
     let installError;
     try {
-        await utils.execAndGetStderr("npm", ["install", `${PKG_SCOPE}/${pkgName}@${pkgTag}`],
+        await utils.execAndGetStderr("npm", ["install", `${PKG_SCOPE}/${pkgName}@${pkgTag}`, ...installArgs],
             { cwd: fs.mkdtempSync(os.tmpdir() + "/zowe") });
         return true;
     } catch (err) {

--- a/zowe-versions.yaml
+++ b/zowe-versions.yaml
@@ -107,7 +107,7 @@ extras:
   secrets-for-kubernetes-for-zowe-cli:
     next: true
   cics-for-zowe-explorer-api:
-    next: true
+    # next: true
     zowe-v3-lts: true
 # Define version info for the latest staged Zowe release.
 tags:


### PR DESCRIPTION
**What It Does**
<!-- A list of relevant issues, enhancements, fixed bugs, etc -->
Fixes Deploy All workflow failing after the addition of `@zowe/cics-for-zowe-explorer-api` package 😋 

**How to Test**
<!-- If a bug has been fixed, how can reviewers verify that the change(s) fixed it? -->
See workflow run https://github.com/zowe/zowe-cli-standalone-package/actions/runs/16473209344

**Review Checklist**
I certify that I have:
- [ ] tested my changes
- [ ] added/updated automated tests
- [ ] updated the changelog
- [ ] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->