### PR TITLE
Fix issues with nightly deploy workflow

### DIFF
--- a/.github/workflows/zowe-cli-coverage.yaml
+++ b/.github/workflows/zowe-cli-coverage.yaml
@@ -21,7 +21,7 @@ jobs:
 
     - run: |
         node scripts/coverage-report.js
-        npx csv2md coverage-report.csv >> $GITHUB_STEP_SUMMARY
+        npx csv-to-markdown-table --delim ',' --headers < coverage-report.csv >> $GITHUB_STEP_SUMMARY
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/zowe-cli-deploy-component.yaml
+++ b/.github/workflows/zowe-cli-deploy-component.yaml
@@ -26,6 +26,11 @@ on:
         description: "Tags to be distributed from Artifactory (separate multiple by spaces)"
         default: "latest"
         required: true
+      dry-run:
+        description: "Test repackaging only and skip publish step"
+        default: false
+        required: false
+        type: boolean
 
 permissions:
   issues: write
@@ -50,7 +55,8 @@ jobs:
     - name: Use Node.js LTS
       uses: actions/setup-node@v4
       with:
-        node-version: 'lts/*'
+        # Stay back one major release to avoid bugs in unstable npm versions
+        node-version: 'lts/-1'
         cache: ${{ (!env.ACT && 'npm') || '' }}
 
     # Python 3.12 breaks node-gyp < 10, breaking current versions of Node 18/20 (as of Nov 9, 2023) - awharn
@@ -97,6 +103,7 @@ jobs:
       id: deploy
       run: node scripts/deploy-component.js ${{ env.PKG_NAME }} ${{ env.PKG_TAGS }}
       env:
+        DRY_RUN: ${{ inputs.dry-run }}
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     
     - name: NPM Logout

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@actions/exec": "^1.1.0",
         "@actions/github": "^6.0.0",
         "adm-zip": "^0.5.10",
-        "csv2md": "^1.1.0",
+        "csv-to-markdown-table": "^1.6.3",
         "delay": "^5.0.0",
         "env-cmd": "^10.1.0",
         "flat": "^5.0.2",
@@ -248,14 +248,6 @@
         "node": ">=6.0"
       }
     },
-    "node_modules/ansi-regex": {
-      "version": "3.0.1",
-      "integrity": "sha512-+O9Jct8wf++lXxxFc4hc8LsjaSq0HFzzL7cVsw8pRDIPdjKD2mT4ytDZlLuSBZ4cLKZFXIrMGO7DbQCtMJJMKw==",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
@@ -280,32 +272,6 @@
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/camelcase": {
-      "version": "5.3.1",
-      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/cliui": {
-      "version": "4.1.0",
-      "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
-      "dev": true,
-      "dependencies": {
-        "string-width": "^2.1.1",
-        "strip-ansi": "^4.0.0",
-        "wrap-ansi": "^2.0.0"
-      }
-    },
-    "node_modules/code-point-at": {
-      "version": "1.1.0",
-      "integrity": "sha512-RpAVKQA5T63xEj6/giIbUEtZwJ4UFIc3ZtvEkiaUERylqe8xb5IvqcgOurZLahv93CLKfxcw5YI+DZcUBRyLXA==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/commander": {
@@ -335,31 +301,13 @@
         "node": ">= 8"
       }
     },
-    "node_modules/csv-parse": {
-      "version": "4.16.3",
-      "integrity": "sha512-cO1I/zmz4w2dcKHVvpCr7JVRu8/FymG5OEpmvsZYlccYolPBLoVGKUHgNoc4ZGkFeFlWGEDmMyBM+TTqRdW/wg==",
-      "dev": true
-    },
-    "node_modules/csv2md": {
-      "version": "1.1.0",
-      "integrity": "sha512-Q66rZDu+2tQZPhkuQyjwMmAnhM64L+k2ax4nNs7FQzbJVJDVOE7gD31pdUzTmtCaIuLbLW1AK1ikj3F4n/GITg==",
+    "node_modules/csv-to-markdown-table": {
+      "version": "1.6.3",
+      "integrity": "sha512-o/s0+YHKbtw4PCTKUxdBwRKzWIi300CvIbqOm+lNmPWc5t9tNCfLfmHUF00CXGwvajPAdFG9XkwRUcL0XZRzjg==",
       "dev": true,
-      "dependencies": {
-        "csv-parse": "^4.11.1",
-        "get-stream": "^5.1.0",
-        "stream-transform": "^2.0.2",
-        "yargs": "^11.1.1"
-      },
+      "license": "MIT",
       "bin": {
-        "csv2md": "bin/csv2md"
-      }
-    },
-    "node_modules/decamelize": {
-      "version": "1.2.0",
-      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
+        "csv-to-markdown-table": "bin/csv-to-markdown-table"
       }
     },
     "node_modules/delay": {
@@ -379,14 +327,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/end-of-stream": {
-      "version": "1.4.4",
-      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
-      "dev": true,
-      "dependencies": {
-        "once": "^1.4.0"
-      }
-    },
     "node_modules/env-cmd": {
       "version": "10.1.0",
       "integrity": "sha512-mMdWTT9XKN7yNth/6N6g2GuKuJTsKMDHlQFUDacb/heQRRWOTIZ42t1rMHnQu4jYxU1ajdTeJM+9eEETlqToMA==",
@@ -402,99 +342,6 @@
         "node": ">=8.0.0"
       }
     },
-    "node_modules/execa": {
-      "version": "1.0.0",
-      "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
-      "dev": true,
-      "dependencies": {
-        "cross-spawn": "^6.0.0",
-        "get-stream": "^4.0.0",
-        "is-stream": "^1.1.0",
-        "npm-run-path": "^2.0.0",
-        "p-finally": "^1.0.0",
-        "signal-exit": "^3.0.0",
-        "strip-eof": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/execa/node_modules/cross-spawn": {
-      "version": "6.0.6",
-      "integrity": "sha512-VqCUuhcd1iB+dsv8gxPttb5iZh/D0iubSP21g36KXdEuf6I5JiioesUVjpCdHV9MZRUfVFlvwtIUyPfxo5trtw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "nice-try": "^1.0.4",
-        "path-key": "^2.0.1",
-        "semver": "^5.5.0",
-        "shebang-command": "^1.2.0",
-        "which": "^1.2.9"
-      },
-      "engines": {
-        "node": ">=4.8"
-      }
-    },
-    "node_modules/execa/node_modules/get-stream": {
-      "version": "4.1.0",
-      "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
-      "dev": true,
-      "dependencies": {
-        "pump": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/execa/node_modules/path-key": {
-      "version": "2.0.1",
-      "integrity": "sha512-fEHGKCSmUSDPv4uoj8AlD+joPlq3peND+HRYyxFz4KPw4z926S/b8rIuFs2FYJg3BwsxJf6A9/3eIdLaYC+9Dw==",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/execa/node_modules/shebang-command": {
-      "version": "1.2.0",
-      "integrity": "sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==",
-      "dev": true,
-      "dependencies": {
-        "shebang-regex": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/execa/node_modules/shebang-regex": {
-      "version": "1.0.0",
-      "integrity": "sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/execa/node_modules/which": {
-      "version": "1.3.1",
-      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
-      "dev": true,
-      "dependencies": {
-        "isexe": "^2.0.0"
-      },
-      "bin": {
-        "which": "bin/which"
-      }
-    },
-    "node_modules/find-up": {
-      "version": "2.1.0",
-      "integrity": "sha512-NWzkk0jSJtTt08+FBFMvXoeZnOJD+jTtsRmBYbAIzJdX6l7dLgR7CTubCM5/eDdPUBvLCeVasP1brfVR/9/EZQ==",
-      "dev": true,
-      "dependencies": {
-        "locate-path": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/flat": {
       "version": "5.0.2",
       "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
@@ -507,25 +354,6 @@
       "version": "1.0.0",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
-    },
-    "node_modules/get-caller-file": {
-      "version": "1.0.3",
-      "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
-      "dev": true
-    },
-    "node_modules/get-stream": {
-      "version": "5.2.0",
-      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
-      "dev": true,
-      "dependencies": {
-        "pump": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/glob": {
       "version": "7.2.0",
@@ -566,30 +394,6 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true
     },
-    "node_modules/invert-kv": {
-      "version": "2.0.0",
-      "integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/is-fullwidth-code-point": {
-      "version": "2.0.0",
-      "integrity": "sha512-VHskAKYM8RfSFXwee5t5cbN5PZeq1Wrh6qd5bkyiXIf6UQcN6w/A0eXM9r6t8d+GYOh+o6ZhiEnb88LN/Y8m2w==",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/is-stream": {
-      "version": "1.1.0",
-      "integrity": "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
@@ -618,61 +422,6 @@
         "graceful-fs": "^4.1.6"
       }
     },
-    "node_modules/lcid": {
-      "version": "2.0.0",
-      "integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
-      "dev": true,
-      "dependencies": {
-        "invert-kv": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/locate-path": {
-      "version": "2.0.0",
-      "integrity": "sha512-NCI2kiDkyR7VeEKm27Kda/iQHyKJe1Bu0FlTbYp3CqJu+9IFe9bLyAjMxf5ZDDbEg+iMPzB5zYyUTSm8wVTKmA==",
-      "dev": true,
-      "dependencies": {
-        "p-locate": "^2.0.0",
-        "path-exists": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/map-age-cleaner": {
-      "version": "0.1.3",
-      "integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
-      "dev": true,
-      "dependencies": {
-        "p-defer": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/mem": {
-      "version": "4.3.0",
-      "integrity": "sha512-qX2bG48pTqYRVmDB37rn/6PT7LcR8T7oAX3bf99u1Tt1nzxYfxkgqDwUwolPlXweM0XzBOBFzSx4kfp7KP1s/w==",
-      "dev": true,
-      "dependencies": {
-        "map-age-cleaner": "^0.1.1",
-        "mimic-fn": "^2.0.0",
-        "p-is-promise": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/mimic-fn": {
-      "version": "2.1.0",
-      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/minimatch": {
       "version": "3.1.2",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
@@ -684,14 +433,6 @@
         "node": "*"
       }
     },
-    "node_modules/mixme": {
-      "version": "0.5.4",
-      "integrity": "sha512-3KYa4m4Vlqx98GPdOHghxSdNtTvcP8E0kkaJ5Dlh+h2DRzF7zpuVVcA8B0QpKd11YJeP9QQ7ASkKzOeu195Wzw==",
-      "dev": true,
-      "engines": {
-        "node": ">= 8.0.0"
-      }
-    },
     "node_modules/moment": {
       "version": "2.29.4",
       "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==",
@@ -699,11 +440,6 @@
       "engines": {
         "node": "*"
       }
-    },
-    "node_modules/nice-try": {
-      "version": "1.0.5",
-      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
-      "dev": true
     },
     "node_modules/node-fetch": {
       "version": "2.6.7",
@@ -724,33 +460,6 @@
         }
       }
     },
-    "node_modules/npm-run-path": {
-      "version": "2.0.2",
-      "integrity": "sha512-lJxZYlT4DW/bRUtFh1MQIWqmLwQfAxnqWG4HhEdjMlkrJYnJn0Jrr2u3mgxqaWsdiBc76TYkTG/mhrnYTuzfHw==",
-      "dev": true,
-      "dependencies": {
-        "path-key": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/npm-run-path/node_modules/path-key": {
-      "version": "2.0.1",
-      "integrity": "sha512-fEHGKCSmUSDPv4uoj8AlD+joPlq3peND+HRYyxFz4KPw4z926S/b8rIuFs2FYJg3BwsxJf6A9/3eIdLaYC+9Dw==",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/number-is-nan": {
-      "version": "1.0.1",
-      "integrity": "sha512-4jbtZXNAsfZbAHiiqjLPBiCl16dES1zI4Hpzzxw61Tk+loF+sBDBKx1ICKKKwIqQ7M0mFn1TmkN7euSncWgHiQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/once": {
       "version": "1.4.0",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
@@ -759,85 +468,10 @@
         "wrappy": "1"
       }
     },
-    "node_modules/os-locale": {
-      "version": "3.1.0",
-      "integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
-      "dev": true,
-      "dependencies": {
-        "execa": "^1.0.0",
-        "lcid": "^2.0.0",
-        "mem": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/p-defer": {
-      "version": "1.0.0",
-      "integrity": "sha512-wB3wfAxZpk2AzOfUMJNL+d36xothRSyj8EXOa4f6GMqYDN9BJaaSISbsk+wS9abmnebVw95C2Kb5t85UmpCxuw==",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/p-finally": {
-      "version": "1.0.0",
-      "integrity": "sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/p-is-promise": {
-      "version": "2.1.0",
-      "integrity": "sha512-Y3W0wlRPK8ZMRbNq97l4M5otioeA5lm1z7bkNkxCka8HSPjR0xRWmpCmc9utiaLP9Jb1eD8BgeIxTW4AIF45Pg==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/p-limit": {
-      "version": "1.3.0",
-      "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
-      "dev": true,
-      "dependencies": {
-        "p-try": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/p-locate": {
-      "version": "2.0.0",
-      "integrity": "sha512-nQja7m7gSKuewoVRen45CtVfODR3crN3goVQ0DDZ9N3yHxgpkuBhZqsaiotSQRrADUrne346peY7kT3TSACykg==",
-      "dev": true,
-      "dependencies": {
-        "p-limit": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/p-try": {
-      "version": "1.0.0",
-      "integrity": "sha512-U1etNYuMJoIz3ZXSrrySFjsXQTWOx2/jdi86L+2pRvph/qMKL6sbcCYdH23fqsbm8TH2Gn0OybpT4eSFlCVHww==",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/parse-lcov": {
       "version": "1.0.4",
       "integrity": "sha512-jE72M66VFyZJ0KYKnmaV70U/Y6FZyPoBCtJ6we5rDIVpWFR/GEkdCSLJn/R3UHJWZ3e3Qf3jAm2AUrmkaso+wA==",
       "dev": true
-    },
-    "node_modules/path-exists": {
-      "version": "3.0.0",
-      "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
     },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
@@ -855,45 +489,9 @@
         "node": ">=8"
       }
     },
-    "node_modules/pump": {
-      "version": "3.0.0",
-      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-      "dev": true,
-      "dependencies": {
-        "end-of-stream": "^1.1.0",
-        "once": "^1.3.1"
-      }
-    },
-    "node_modules/require-directory": {
-      "version": "2.1.1",
-      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/require-main-filename": {
-      "version": "1.0.1",
-      "integrity": "sha512-IqSUtOVP4ksd1C/ej5zeEh/BIP2ajqpn8c5x+q99gvcIG/Qf0cud5raVnE/Dwd0ua9TXYDoDc0RE5hBSdz22Ug==",
-      "dev": true
-    },
     "node_modules/sax": {
       "version": "1.2.4",
       "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
-      "dev": true
-    },
-    "node_modules/semver": {
-      "version": "5.7.2",
-      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver"
-      }
-    },
-    "node_modules/set-blocking": {
-      "version": "2.0.0",
-      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
       "dev": true
     },
     "node_modules/shebang-command": {
@@ -923,56 +521,12 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/signal-exit": {
-      "version": "3.0.7",
-      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-      "dev": true
-    },
-    "node_modules/stream-transform": {
-      "version": "2.1.3",
-      "integrity": "sha512-9GHUiM5hMiCi6Y03jD2ARC1ettBXkQBoQAe7nJsPknnI0ow10aXjTnew8QtYQmLjzn974BnmWEAJgCY6ZP1DeQ==",
-      "dev": true,
-      "dependencies": {
-        "mixme": "^0.5.1"
-      }
-    },
-    "node_modules/string-width": {
-      "version": "2.1.1",
-      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-      "dev": true,
-      "dependencies": {
-        "is-fullwidth-code-point": "^2.0.0",
-        "strip-ansi": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/strip-ansi": {
-      "version": "4.0.0",
-      "integrity": "sha512-4XaJ2zQdCzROZDivEVIDPkcQn8LMFSa8kj8Gxb/Lnwzv9A8VctNZ+lfivC/sV3ivW8ElJTERXZoPBRrZKkNKow==",
-      "dev": true,
-      "dependencies": {
-        "ansi-regex": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/strip-comments": {
       "version": "2.0.1",
       "integrity": "sha512-ZprKx+bBLXv067WTCALv8SSz5l2+XhpYCsVtSqlMnkAXMWDq+/ekVbl1ghqP9rUHTzv6sm/DwCOiYutU/yp1fw==",
       "dev": true,
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/strip-eof": {
-      "version": "1.0.0",
-      "integrity": "sha512-7FCwGGmx8mD5xQd3RPUvnSpUXHM3BWuzjtpD4TXsfcZ9EL4azvVVUscFYwD9nx8Kh+uCBC00XBtAykoMHwTh8Q==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/tr46": {
@@ -1050,66 +604,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/which-module": {
-      "version": "2.0.0",
-      "integrity": "sha512-B+enWhmw6cjfVC7kS8Pj9pCrKSc5txArRyaYGe088shv/FGWH+0Rjx/xPgtsWfsUtS27FkP697E4DDhgrgoc0Q==",
-      "dev": true
-    },
-    "node_modules/wrap-ansi": {
-      "version": "2.1.0",
-      "integrity": "sha512-vAaEaDM946gbNpH5pLVNR+vX2ht6n0Bt3GXwVB1AuAqZosOvHNF3P7wDnh8KLkSqgUh0uh77le7Owgoz+Z9XBw==",
-      "dev": true,
-      "dependencies": {
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/wrap-ansi/node_modules/ansi-regex": {
-      "version": "2.1.1",
-      "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/wrap-ansi/node_modules/is-fullwidth-code-point": {
-      "version": "1.0.0",
-      "integrity": "sha512-1pqUqRjkhPJ9miNq9SwMfdvi6lBJcd6eFxvfaivQhaH3SgisfiuudvFntdKOmxuee/77l+FPjKrQjWvmPjWrRw==",
-      "dev": true,
-      "dependencies": {
-        "number-is-nan": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/wrap-ansi/node_modules/string-width": {
-      "version": "1.0.2",
-      "integrity": "sha512-0XsVpQLnVCXHJfyEs8tC0zpTVIr5PKKsQtkT29IwupnPTjtPmQ3xT/4yCREF9hYkV/3M3kzcUTSAZT6a6h81tw==",
-      "dev": true,
-      "dependencies": {
-        "code-point-at": "^1.0.0",
-        "is-fullwidth-code-point": "^1.0.0",
-        "strip-ansi": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/wrap-ansi/node_modules/strip-ansi": {
-      "version": "3.0.1",
-      "integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
-      "dev": true,
-      "dependencies": {
-        "ansi-regex": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
@@ -1124,39 +618,6 @@
       },
       "bin": {
         "xml-js": "bin/cli.js"
-      }
-    },
-    "node_modules/y18n": {
-      "version": "3.2.2",
-      "integrity": "sha512-uGZHXkHnhF0XeeAPgnKfPv1bgKAYyVvmNL1xlKsPYZPaIHxGti2hHqvOCQv71XMsLxu1QjergkqogUnms5D3YQ==",
-      "dev": true
-    },
-    "node_modules/yargs": {
-      "version": "11.1.1",
-      "integrity": "sha512-PRU7gJrJaXv3q3yQZ/+/X6KBswZiaQ+zOmdprZcouPYtQgvNU35i+68M4b1ZHLZtYFT5QObFLV+ZkmJYcwKdiw==",
-      "dev": true,
-      "dependencies": {
-        "cliui": "^4.0.0",
-        "decamelize": "^1.1.1",
-        "find-up": "^2.1.0",
-        "get-caller-file": "^1.0.1",
-        "os-locale": "^3.1.0",
-        "require-directory": "^2.1.1",
-        "require-main-filename": "^1.0.1",
-        "set-blocking": "^2.0.0",
-        "string-width": "^2.0.0",
-        "which-module": "^2.0.0",
-        "y18n": "^3.2.1",
-        "yargs-parser": "^9.0.2"
-      }
-    },
-    "node_modules/yargs-parser": {
-      "version": "13.1.2",
-      "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
-      "dev": true,
-      "dependencies": {
-        "camelcase": "^5.0.0",
-        "decamelize": "^1.2.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@actions/exec": "^1.1.0",
     "@actions/github": "^6.0.0",
     "adm-zip": "^0.5.10",
-    "csv2md": "^1.1.0",
+    "csv-to-markdown-table": "^1.6.3",
     "delay": "^5.0.0",
     "env-cmd": "^10.1.0",
     "flat": "^5.0.2",
@@ -36,8 +36,5 @@
     "shebang-regex": "^2.0.0",
     "strip-comments": "^2.0.1",
     "xml-js": "^1.6.11"
-  },
-  "overrides": {
-    "yargs-parser": "~13.1.2"
   }
 }

--- a/scripts/deploy-component.js
+++ b/scripts/deploy-component.js
@@ -46,7 +46,7 @@ async function deploy(pkgName, pkgTag) {
         core.warning(`Package ${PKG_SCOPE}/${pkgName}@${pkgVersion} will not be published because it failed to ` +
             `install`);
         return;
-    } else if (oldPkgVersion === pkgVersion) {
+    } else if (oldPkgVersion === pkgVersion && !DRY_RUN) {
         core.info(`Package ${PKG_SCOPE}/${pkgName}@${pkgVersion} already exists`);
         return;
     } else if (pkgTag !== pkgVersion && await utils.shouldSkipPublish(pkgName, pkgTag, pkgVersion)) {
@@ -62,14 +62,15 @@ async function deploy(pkgName, pkgTag) {
     } catch {}
     if (versionExists && !DRY_RUN) {
         core.info(`Package ${PKG_SCOPE}/${pkgName}@${pkgVersion} already exists, adding tag ${pkgTag}`);
-        await utils.execAndGetStderr("npm", ["dist-tag", "add", `${PKG_SCOPE}/${pkgName}@${pkgVersion}`, pkgTag]);    
+        await utils.execAndGetStderr("npm", ["dist-tag", "add", `${PKG_SCOPE}/${pkgName}@${pkgVersion}`, pkgTag]);
     } else {
         const tgzUrl = await utils.getPackageInfo(`${PKG_SCOPE}/${pkgName}@${pkgTag}`, VIEW_OPTS, "dist.tarball");
         const fullPkgName = `${pkgName}-${pkgVersion}.tgz`;
         await utils.execAndGetStderr("curl", ["-fsL", "-o", fullPkgName, tgzUrl]);
         await utils.execAndGetStderr("bash", ["scripts/repackage_tar.sh", fullPkgName, TARGET_REGISTRY, pkgVersion]);
         pkgTag = pkgTag !== pkgVersion ? pkgTag : TEMP_NPM_TAG;
-        if (!DRY_RUN) await utils.execAndGetStderr("npm", ["publish", fullPkgName, "--access", "public", "--tag", pkgTag]);
+        if (DRY_RUN) return;
+        await utils.execAndGetStderr("npm", ["publish", fullPkgName, "--access", "public", "--tag", pkgTag]);
     }
 
     core.info("Waiting for published version to appear on NPM registry");

--- a/scripts/deploy-component.js
+++ b/scripts/deploy-component.js
@@ -59,7 +59,9 @@ async function deploy(pkgName, pkgTag) {
     try {
         oldPkgVersion = await utils.getPackageInfo(`${PKG_SCOPE}/${pkgName}@${pkgVersion}`);
         versionExists = true;
-    } catch {}
+    } catch (err) {
+        core.info(`Could not find package ${PKG_SCOPE}/${pkgName}@${pkgVersion}: ${err.message}`);
+    }
     if (versionExists && !DRY_RUN) {
         core.info(`Package ${PKG_SCOPE}/${pkgName}@${pkgVersion} already exists, adding tag ${pkgTag}`);
         await utils.execAndGetStderr("npm", ["dist-tag", "add", `${PKG_SCOPE}/${pkgName}@${pkgVersion}`, pkgTag]);

--- a/scripts/deploy-component.js
+++ b/scripts/deploy-component.js
@@ -17,6 +17,7 @@ const jsYaml = require("js-yaml");
 
 const utils = require(__dirname + "/utils");
 
+const DRY_RUN = process.env.DRY_RUN === "true";
 const PKG_SCOPE = "@zowe";
 const SOURCE_REGISTRY = "https://zowe.jfrog.io/zowe/api/npm/npm-local-release/";
 const TARGET_REGISTRY = process.env.NPM_REGISTRY || "https://registry.npmjs.org/";
@@ -54,22 +55,26 @@ async function deploy(pkgName, pkgTag) {
         return;
     }
 
+    let versionExists = false;
     try {
         oldPkgVersion = await utils.getPackageInfo(`${PKG_SCOPE}/${pkgName}@${pkgVersion}`);
+        versionExists = true;
+    } catch {}
+    if (versionExists && !DRY_RUN) {
         core.info(`Package ${PKG_SCOPE}/${pkgName}@${pkgVersion} already exists, adding tag ${pkgTag}`);
-        await utils.execAndGetStderr("npm", ["dist-tag", "add", `${PKG_SCOPE}/${pkgName}@${pkgVersion}`, pkgTag]);
-    } catch (err) {
+        await utils.execAndGetStderr("npm", ["dist-tag", "add", `${PKG_SCOPE}/${pkgName}@${pkgVersion}`, pkgTag]);    
+    } else {
         const tgzUrl = await utils.getPackageInfo(`${PKG_SCOPE}/${pkgName}@${pkgTag}`, VIEW_OPTS, "dist.tarball");
         const fullPkgName = `${pkgName}-${pkgVersion}.tgz`;
         await utils.execAndGetStderr("curl", ["-fsL", "-o", fullPkgName, tgzUrl]);
         await utils.execAndGetStderr("bash", ["scripts/repackage_tar.sh", fullPkgName, TARGET_REGISTRY, pkgVersion]);
         pkgTag = pkgTag !== pkgVersion ? pkgTag : TEMP_NPM_TAG;
-        await utils.execAndGetStderr("npm", ["publish", fullPkgName, "--access", "public", "--tag", pkgTag]);
+        if (!DRY_RUN) await utils.execAndGetStderr("npm", ["publish", fullPkgName, "--access", "public", "--tag", pkgTag]);
     }
 
     core.info("Waiting for published version to appear on NPM registry");
     let taggedVersion;
-    let versionExists = false;
+    versionExists = false;
     while (!versionExists || taggedVersion !== pkgVersion) {
         if (!versionExists) {
             versionExists = (await exec.getExecOutput("npm", ["view", `${PKG_SCOPE}/${pkgName}@${pkgVersion}`,

--- a/scripts/repackage_tar.sh
+++ b/scripts/repackage_tar.sh
@@ -53,7 +53,7 @@ done
 # Update npm-shrinkwrap.json if necessary
 if [ -e "npm-shrinkwrap.json" ]; then
     # Create a production environment (taking in consideration the npm-shrinkwrap)
-    npm install --omit=dev --ignore-scripts --save=false
+    npm install --only=prod --ignore-scripts
 
     # Rewrite the shrinkwrap file with only production dependencies and public npm resolved URLs
     node "../../scripts/rewrite-shrinkwrap.js"

--- a/scripts/repackage_tar.sh
+++ b/scripts/repackage_tar.sh
@@ -53,7 +53,7 @@ done
 # Update npm-shrinkwrap.json if necessary
 if [ -e "npm-shrinkwrap.json" ]; then
     # Create a production environment (taking in consideration the npm-shrinkwrap)
-    npm install --only=prod --ignore-scripts
+    npm install --omit=dev --ignore-scripts --save=false --@zowe:registry=https://zowe.jfrog.io/zowe/api/npm/npm-local-release/
 
     # Rewrite the shrinkwrap file with only production dependencies and public npm resolved URLs
     node "../../scripts/rewrite-shrinkwrap.js"

--- a/zowe-versions.yaml
+++ b/zowe-versions.yaml
@@ -12,86 +12,85 @@
 packages:
   # Core CLI and SDKs
   perf-timing:
-    next: false
     zowe-v2-lts: 1.0.7
   imperative:
-    next: true
+    # next: true
     zowe-v2-lts: 5.27.12
     zowe-v3-lts: 8.29.4
   cli-test-utils:
-    next: true
+    # next: true
     zowe-v2-lts: 7.29.17
     zowe-v3-lts: 8.29.4
   secrets-for-zowe-sdk:
-    next: true
+    # next: true
     zowe-v2-lts: 7.18.6
     zowe-v3-lts: 8.29.4
   core-for-zowe-sdk:
-    next: true
+    # next: true
     zowe-v2-lts: 7.29.17
     zowe-v3-lts: 8.29.4
   zos-uss-for-zowe-sdk:
-    next: true
+    # next: true
     zowe-v2-lts: 7.29.17
     zowe-v3-lts: 8.29.4
   provisioning-for-zowe-sdk:
-    next: true
+    # next: true
     zowe-v2-lts: 7.29.17
     zowe-v3-lts: 8.29.4
   zos-console-for-zowe-sdk:
-    next: true
+    # next: true
     zowe-v2-lts: 7.29.17
     zowe-v3-lts: 8.29.4
   zos-files-for-zowe-sdk:
-    next: true
+    # next: true
     zowe-v2-lts: 7.29.17
     zowe-v3-lts: 8.29.4
   zos-logs-for-zowe-sdk:
-    next: true
+    # next: true
     zowe-v2-lts: 7.29.17
     zowe-v3-lts: 8.29.4
   zosmf-for-zowe-sdk:
-    next: true
+    # next: true
     zowe-v2-lts: 7.29.17
     zowe-v3-lts: 8.29.4
   zos-workflows-for-zowe-sdk:
-    next: true
+    # next: true
     zowe-v2-lts: 7.29.17
     zowe-v3-lts: 8.29.4
   zos-jobs-for-zowe-sdk:
-    next: true
+    # next: true
     zowe-v2-lts: 7.29.17
     zowe-v3-lts: 8.29.4
   zos-tso-for-zowe-sdk:
-    next: true
+    # next: true
     zowe-v2-lts: 7.29.17
     zowe-v3-lts: 8.29.4
   cli:
-    next: true
+    # next: true
     zowe-v2-lts: 7.29.18
     zowe-v3-lts: 8.29.5
   # CLI plug-ins
   cics-for-zowe-sdk:
-    next: true
+    # next: true
     zowe-v2-lts: 5.0.9
     zowe-v3-lts: 6.13.2
   cics-for-zowe-cli:
-    next: true
+    # next: true
     zowe-v2-lts: 5.0.9
     zowe-v3-lts: 6.13.2
   db2-for-zowe-cli:
-    next: true
+    # next: true
     zowe-v2-lts: 5.0.19
     zowe-v3-lts: 6.1.9
   ims-for-zowe-cli:
-    next: true
+    # next: true
     zowe-v2-lts: 3.0.1
   mq-for-zowe-cli:
-    next: true
+    # next: true
     zowe-v2-lts: 3.0.1
     zowe-v3-lts: 4.0.0
   zos-ftp-for-zowe-cli:
-    next: true
+    # next: true
     zowe-v2-lts: 2.1.9
     zowe-v3-lts: 3.0.0
 # Define extra @zowe-scoped packages that are not included in the Zowe bundle.


### PR DESCRIPTION
**What It Does**
<!-- A list of relevant issues, enhancements, fixed bugs, etc -->
* Disables publishing `@next` tag for packages until we're ready to ship Zowe vNext prereleases again. This should speed up smoke tests and fix failing ones for DB2 CLI plug-in on MacOS ARM.
* Defines `@zowe:registry` in `repackage_tar.sh` which fixes SHA mismatch when publishing CICS CLI plug-in. Previously this wasn't necessary because npm could determine package registry based on `resolved` field in the shrinkwrap.
* Adds dry run mode to deploy workflow to make it easier to test changes to repackaging process without publishing.
* Adopts Node version `lts/-1` in deploy workflow since new Node versions like 24 had serious npm bugs for a while.
* Replaces `csv2md` dev dep with `csv-to-markdown-table` which is actively maintained and has fewer dependencies.

**How to Test**
<!-- If a bug has been fixed, how can reviewers verify that the change(s) fixed it? -->
See passing workflow here: https://github.com/zowe/zowe-cli-standalone-package/actions/runs/20529349878

**Review Checklist**
I certify that I have:
- [ ] tested my changes
- [ ] added/updated automated tests
- [ ] updated the changelog
- [ ] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->