### PR TITLE
tolerate existence of temp before running repackage_tar.sh & repackage_bundle.sh

### DIFF
--- a/scripts/repackage_bundle.sh
+++ b/scripts/repackage_bundle.sh
@@ -16,7 +16,7 @@ mkdir -p packed
 # Loop through each tar (representing an `npm pack`), and create new tars with packed dependencies.
 for tar in "$@"
 do
-    mkdir temp
+    mkdir -p temp
     tar xzf $tar -C temp
 
     # Changes the package.json format

--- a/scripts/repackage_tar.sh
+++ b/scripts/repackage_tar.sh
@@ -22,7 +22,7 @@ tarfile=$1;
 registry=$2;
 newversion=$3;
 
-mkdir temp
+mkdir -p temp
 tar xzf $tarfile -C temp
 cd temp
 cd package


### PR DESCRIPTION
**What It Does**
<!-- A list of relevant issues, enhancements, fixed bugs, etc -->

Hope to fix: 
```
/usr/bin/bash scripts/repackage_tar.sh cli-8.35.3.tgz https://registry.npmjs.org/ 8.35.3
mkdir: cannot create directory ‘temp’: File exists
Error: Error: The command 'bash scripts/repackage_tar.sh cli-8.35.3.tgz https://registry.npmjs.org/ 8.35.3' failed with exit code 1
mkdir: cannot create directory ‘temp’: File exists
Error: AggregateError
Error: Process completed with exit code 1. 
``` 

**How to Test**
<!-- If a bug has been fixed, how can reviewers verify that the change(s) fixed it? -->

**Review Checklist**
I certify that I have:
- [ ] tested my changes
- [ ] added/updated automated tests
- [ ] updated the changelog
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->